### PR TITLE
Add new sythesis recipes of 2.4

### DIFF
--- a/EDEngineer/Resources/Data/blueprints.json
+++ b/EDEngineer/Resources/Data/blueprints.json
@@ -14205,7 +14205,7 @@
   },
   {
     "Type": "Life Support",
-    "Name": "",
+    "Name": "100% Refill",
     "Engineers": [ "@Synthesis" ],
     "Ingredients": [
       {

--- a/EDEngineer/Resources/Data/blueprints.json
+++ b/EDEngineer/Resources/Data/blueprints.json
@@ -14204,7 +14204,7 @@
     "Grade": 5
   },
   {
-    "Type": "Life Support Refill",
+    "Type": "Life Support",
     "Name": "",
     "Engineers": [ "@Synthesis" ],
     "Ingredients": [
@@ -14236,7 +14236,7 @@
     "Grade": 1
   },
   {
-    "Type": "Chaff Launcher Refill",
+    "Type": "Chaff Launcher",
     "Name": "50% Refill",
     "Engineers": [ "@Synthesis" ],
     "Ingredients": [
@@ -14252,7 +14252,7 @@
     "Grade": 1
   },
   {
-    "Type": "Chaff Launcher Refill",
+    "Type": "Chaff Launcher",
     "Name": "100% Refill",
     "Engineers": [ "@Synthesis" ],
     "Ingredients": [
@@ -14272,7 +14272,7 @@
     "Grade": 2
   },
   {
-    "Type": "Chaff Launcher Refill",
+    "Type": "Chaff Launcher",
     "Name": "100% Refill, +2 Seconds Duration",
     "Engineers": [ "@Synthesis" ],
     "Ingredients": [
@@ -14296,7 +14296,7 @@
     "Grade": 3
   },
   {
-    "Type": "Heat Sink Launcher Refill",
+    "Type": "Heat Sink Launcher",
     "Name": "50% Refill",
     "Engineers": [ "@Synthesis" ],
     "Ingredients": [
@@ -14312,7 +14312,7 @@
     "Grade": 1
   },
   {
-    "Type": "Heat Sink Launcher Refill",
+    "Type": "Heat Sink Launcher",
     "Name": "100% Refill, +15% Heat Dissipation",
     "Engineers": [ "@Synthesis" ],
     "Ingredients": [
@@ -14332,7 +14332,7 @@
     "Grade": 2
   },
   {
-    "Type": "Heat Sink Launcher Refill",
+    "Type": "Heat Sink Launcher",
     "Name": "100% Refill, +30% Heat Dissipation",
     "Engineers": [ "@Synthesis" ],
     "Ingredients": [

--- a/EDEngineer/Resources/Data/blueprints.json
+++ b/EDEngineer/Resources/Data/blueprints.json
@@ -14204,6 +14204,158 @@
     "Grade": 5
   },
   {
+    "Type": "Life Support Refill",
+    "Name": "",
+    "Engineers": [ "@Synthesis" ],
+    "Ingredients": [
+      {
+        "Name": "Iron",
+        "Size": 2
+      },
+      {
+        "Name": "Nickel",
+        "Size": 1
+      }
+    ],
+    "Grade": 1
+  },
+  {
+    "Type": "Limpets",
+    "Name": "4 Limpets, Cargo Hold Required",
+    "Engineers": [ "@Synthesis" ],
+    "Ingredients": [
+      {
+        "Name": "Iron",
+        "Size": 10
+      },
+      {
+        "Name": "Nickel",
+        "Size": 10
+      }
+    ],
+    "Grade": 1
+  },
+  {
+    "Type": "Chaff Launcher Refill",
+    "Name": "50% Refill",
+    "Engineers": [ "@Synthesis" ],
+    "Ingredients": [
+      {
+        "Name": "Compact Composites",
+        "Size": 1
+      },
+      {
+        "Name": "Filament Composites",
+        "Size": 1
+      }
+    ],
+    "Grade": 1
+  },
+  {
+    "Type": "Chaff Launcher Refill",
+    "Name": "100% Refill",
+    "Engineers": [ "@Synthesis" ],
+    "Ingredients": [
+      {
+        "Name": "Compact Composites",
+        "Size": 1
+      },
+      {
+        "Name": "Filament Composites",
+        "Size": 2
+      },
+      {
+        "Name": "Thermic Alloys",
+        "Size": 1
+      }
+    ],
+    "Grade": 2
+  },
+  {
+    "Type": "Chaff Launcher Refill",
+    "Name": "100% Refill, +2 Seconds Duration",
+    "Engineers": [ "@Synthesis" ],
+    "Ingredients": [
+      {
+        "Name": "Compact Composites",
+        "Size": 1
+      },
+      {
+        "Name": "Filament Composites",
+        "Size": 2
+      },
+      {
+        "Name": "Thermic Alloys",
+        "Size": 2
+      },
+      {
+        "Name": "Proto Radiolic Alloys",
+        "Size": 1
+      }
+    ],
+    "Grade": 3
+  },
+  {
+    "Type": "Heat Sink Launcher Refill",
+    "Name": "50% Refill",
+    "Engineers": [ "@Synthesis" ],
+    "Ingredients": [
+      {
+        "Name": "Basic Conductors",
+        "Size": 2
+      },
+      {
+        "Name": "Heat Conduction Wiring",
+        "Size": 2
+      }
+    ],
+    "Grade": 1
+  },
+  {
+    "Type": "Heat Sink Launcher Refill",
+    "Name": "100% Refill, +15% Heat Dissipation",
+    "Engineers": [ "@Synthesis" ],
+    "Ingredients": [
+      {
+        "Name": "Basic Conductors",
+        "Size": 2
+      },
+      {
+        "Name": "Heat Conduction Wiring",
+        "Size": 2
+      },
+      {
+        "Name": "Heat Exchangers",
+        "Size": 2
+      }
+    ],
+    "Grade": 2
+  },
+  {
+    "Type": "Heat Sink Launcher Refill",
+    "Name": "100% Refill, +30% Heat Dissipation",
+    "Engineers": [ "@Synthesis" ],
+    "Ingredients": [
+      {
+        "Name": "Basic Conductors",
+        "Size": 2
+      },
+      {
+        "Name": "Heat Conduction Wiring",
+        "Size": 2
+      },
+      {
+        "Name": "Heat Exchangers",
+        "Size": 2
+      },
+      {
+        "Name": "Proto Heat Radiators",
+        "Size": 1
+      }
+    ],
+    "Grade": 3
+  },
+  {
     "Type": "FSD Injection",
     "Name": "+25% Jump Range",
     "Engineers": [ "@Synthesis" ],


### PR DESCRIPTION
Fix issue #255 by adding the new synthesis recipes of 2.4.  I am not 100% sure if the word "Refill" should be part of the type.  Without it, the synthesis recipes might get added to the engineer blueprints for life support/heat sink/chaff launcher; if that would be a good or bad thing is open for debate.