### PR TITLE
German localisation: 2nd Attempt

### DIFF
--- a/EDEngineer/Resources/Data/localization.json
+++ b/EDEngineer/Resources/Data/localization.json
@@ -18,7 +18,7 @@
     "de": {
       "TwoLetterISOLanguageName": "de",
       "Name": "Deutsch",
-      "NotReadyWarning": "Diese Übersetzung ist unvollständig! Wenn Sie es auswählen, werden nur Teile der Anwendung übersetzt. Alles, was noch nicht übersetzt wurde, wird auf Englisch angezeigt."
+      "NotReadyWarning": "Diese Übersetzung ist unvollständig! Wenn Sie sie auswählen, werden nur Teile der Anwendung übersetzt. Alles, was noch nicht übersetzt wurde, wird auf Englisch angezeigt."
     },
     "fr": {
       "TwoLetterISOLanguageName": "fr",
@@ -648,7 +648,7 @@
     "Hatch Breaker Limpet Controller": {
       "es": "Lanzador Dron Extractor",
       "pt": "Controlador de Drone Quebra-Escotilha",
-      "de": "Steuerung Ladelukenöffner-Drohne",
+      "de": "Steuereinheit Ladelukenöffner-Drohne",
       "fr": "Perce-Soute",
       "ru": "Контроллер дронов взломщиков",
       "pl": "Hatch Breaker Limpet Controller"
@@ -1840,7 +1840,7 @@
     "AFMU": {
       "es": "Unidad de Automantenimiento",
       "pt": "UMTS",
-      "de": "AFWE",
+      "de": "AFW",
       "fr": "MTA",
       "ru": "БАПР",
       "pl": "AFMU"
@@ -2936,7 +2936,7 @@
     "Apply": {
       "es": null,
       "pt": "Aplicar",
-      "de": "anwenden",
+      "de": "Anwenden",
       "fr": "Appliquer",
       "ru": "Применить",
       "pl": "Zastosuj"
@@ -3424,7 +3424,7 @@
     "Raw": {
       "es": null,
       "pt": null,
-      "de": null,
+      "de": "roh",
       "fr": null,
       "ru": null,
       "pl": null
@@ -3432,7 +3432,7 @@
     "Raw Only": {
       "es": null,
       "pt": null,
-      "de": null,
+      "de": "nur roh",
       "fr": null,
       "ru": null,
       "pl": null
@@ -3440,7 +3440,7 @@
     "Manufactured": {
       "es": null,
       "pt": null,
-      "de": null,
+      "de": "hergestellt",
       "fr": null,
       "ru": null,
       "pl": null
@@ -3448,7 +3448,7 @@
     "Manufactured Only": {
       "es": null,
       "pt": null,
-      "de": null,
+      "de": "nur hergestellt",
       "fr": null,
       "ru": null,
       "pl": null


### PR DESCRIPTION
OK
Last time was really stupid on my part, i just changed anything that didn´t sound entirely right, 
without looking even once at the german ED translation.

This time, i only changed things i am 100% shure about.

Line 21 is still a grammar error.
Line 651 is something i checked ingame. In the starport, it says "Steuereinheit", not "Steuerung".
Same goes for line 1843. "Automatische Feldwartungs-Einheit" is short "AFW" in the shop´s category screen, not "AFWE"
Line 2939 is most likely going to be a button of some sort(?) If "Apply", "Aplicar", and "Appliquer" are written with a capital letter, why not "anwenden"?
The last four changes are all new translations. Could you perhaps tell me in which context "Raw" and "Raw Only" are being used, the german translation could vary, "roh"/"nur roh" may not be accurate.

Anyway, this new PR should not be as problematic as the last one^^.

Kind Regards
Kai Kiehl

Fly Safe o7