### PR TITLE
Premium FSD Injection only needs one Niobium, not three

### DIFF
--- a/EDEngineer/Resources/Data/blueprints.json
+++ b/EDEngineer/Resources/Data/blueprints.json
@@ -16353,7 +16353,7 @@
       },
       {
         "Name": "Niobium",
-        "Size": 3
+        "Size": 1
       },
       {
         "Name": "Yttrium",


### PR DESCRIPTION
Noticed a small bug in the premium FSD injection: It only needs one Niobium in 3.0, not three 