### PR TITLE
Typo fix in blueprints.json

### DIFF
--- a/EDEngineer/Resources/Data/blueprints.json
+++ b/EDEngineer/Resources/Data/blueprints.json
@@ -22864,7 +22864,7 @@
   },
   {
     "Type": "Frame Shift Drive",
-    "Name": "Mass Menager",
+    "Name": "Mass Manager",
     "Ingredients": [
       {
         "Name": "Atypical Disrupted Wake Echoes",


### PR DESCRIPTION
Typo, "Mass Menager" -> "Mass Manager"