### PR TITLE
Typo fix for localization.json

### DIFF
--- a/EDEngineer/Resources/Data/localization.json
+++ b/EDEngineer/Resources/Data/localization.json
@@ -4317,7 +4317,7 @@
       "ru": null,
       "pl": null
     },
-    "Mass Menager": {
+    "Mass Manager": {
       "es": null,
       "pt": null,
       "de": null,


### PR DESCRIPTION
Typo fix, "Mass Menager" -> "Mass Manager" to match blueprints.json