### PR TITLE
Attempt fixing Toast

### DIFF
--- a/EDEngineer/Views/Notifications/CommanderNotifications.cs
+++ b/EDEngineer/Views/Notifications/CommanderNotifications.cs
@@ -11,6 +11,7 @@ using EDEngineer.Localization;
 using EDEngineer.Models;
 using EDEngineer.Models.State;
 using EDEngineer.Utils.System;
+using System.Reflection;
 
 namespace EDEngineer.Views.Notifications
 {
@@ -111,7 +112,8 @@ namespace EDEngineer.Views.Notifications
                 imageElements[0].Attributes.GetNamedItem("src").NodeValue = imagePath;
 
                 var toast = new ToastNotification(toastXml);
-                ToastNotificationManager.CreateToastNotifier("EDEngineer").Show(toast);
+                var id = Assembly.GetExecutingAssembly().GetType().GUID.ToString();
+                ToastNotificationManager.CreateToastNotifier(id).Show(toast);
             }
             catch (Exception)
             {


### PR DESCRIPTION
Attempted fixing toasts by getting guid of executing assembly and passing it to the ToastNotificationManager
(Needs testing in full install as the ToastNotificationManager checks if the guid passed to it matches that of an installed application, meaning the guid  returned when running a debug build wont match that of any installed programm)