### PR TITLE
Update blueprints.json

### DIFF
--- a/EDEngineer/Resources/Data/blueprints.json
+++ b/EDEngineer/Resources/Data/blueprints.json
@@ -28359,7 +28359,10 @@
       {
         "Name": "Focus Crystals",
         "Size": 10
-      }
+      },
+      {
+        "Name": "Guardian Technology Component",
+        "Size": 6
     ],
     "Grade": 3
   },


### PR DESCRIPTION
Guardian Gauss Cannon Munitions was missing Guardian Technology Components, 6 needed in the blueprint