### PR TITLE
Split both Guardian and Thargoid items into two subgroups (4 groups total)

### DIFF
--- a/EDEngineer.Models/EntryData.cs
+++ b/EDEngineer.Models/EntryData.cs
@@ -54,6 +54,14 @@ namespace EDEngineer.Models
         [JsonIgnore]
         public bool Unused { get; set; }
 
+        public bool IsTradeable()
+        {
+            return
+                Rarity.Rank().HasValue &&
+                Group.HasValue &&
+                !Group.In(Models.Group.ThargoidShip, Models.Group.ThargoidSite, Models.Group.GuardianRuins, Models.Group.GuardianRuinsActive, Models.Group.Commodities);
+        }
+
         private static Origin GuessOrigin(string text)
         {
             if (text.Contains("Markets"))

--- a/EDEngineer.Models/Group.cs
+++ b/EDEngineer.Models/Group.cs
@@ -73,11 +73,17 @@ namespace EDEngineer.Models
         [Description("Alloys")]
         Alloys,
 
-        [Description("Thargoid")]
-        Thargoid,
+        [Description("Thargoid Ship")]
+        ThargoidShip,
 
-        [Description("Guardian")]
-        Guardian,
+        [Description("Thargoid Site")]
+        ThargoidSite,
+
+        [Description("Guardian Ruins")]
+        GuardianRuins,
+
+        [Description("Guardian Ruins (Active)")]
+        GuardianRuinsActive,
 
         [Description("Commodities")]
         Commodities

--- a/EDEngineer.Models/MaterialTrading/MaterialTrader.cs
+++ b/EDEngineer.Models/MaterialTrading/MaterialTrader.cs
@@ -12,11 +12,7 @@ namespace EDEngineer.Models.MaterialTrading
         {
             var ingredients = cargo.Ingredients.Values
                                    .Where(i => i.Count > 0 && 
-                                               i.Data.Group.HasValue && 
-                                               i.Data.Group != Group.Thargoid &&
-                                               i.Data.Group != Group.Guardian &&
-                                               i.Data.Group != Group.Commodities &&
-                                               i.Data.Rarity.Rank() != null &&
+                                               i.Data.IsTradeable() &&
                                                !missingIngredients.ContainsKey(i)).ToList();
 
             var allTrades = AllTrades(missingIngredients, ingredients, deduced).ToList();
@@ -74,10 +70,7 @@ namespace EDEngineer.Models.MaterialTrading
                 var ingredient = missingIngredient.Key;
                 var missingSize = missingIngredient.Value;
 
-                if (missingSize <= 0 ||
-                    !ingredient.Data.Group.HasValue ||
-                    ingredient.Data.Group.In(Group.Thargoid, Group.Guardian, Group.Commodities) ||
-                    !ingredient.Data.Rarity.Rank().HasValue)
+                if (missingSize <= 0 || !ingredient.Data.IsTradeable())
                 {
                     continue;
                 }

--- a/EDEngineer/Resources/Data/entryData.json
+++ b/EDEngineer/Resources/Data/entryData.json
@@ -938,53 +938,53 @@
     "OriginDetails": [
       "Ancient/Guardian ruins"
     ],
-    "Group": "Guardian",
+    "Group": "GuardianRuins",
     "MaximumCapacity": 150
   },
-  {
-    "Name": "Pattern Beta Obelisk Data",
-    "Rarity": "Common",
-    "FormattedName": "ancientculturaldata",
-    "Kind": "Data",
-    "OriginDetails": [
-      "Ancient/Guardian ruins"
-    ],
-    "Group": "Guardian",
-    "MaximumCapacity": 150
-  },
-  {
-    "Name": "Pattern Delta Obelisk Data",
-    "Rarity": "Rare",
-    "FormattedName": "ancientlanguagedata",
-    "Kind": "Data",
-    "OriginDetails": [
-      "Ancient/Guardian ruins"
-    ],
-    "Group": "Guardian",
-    "MaximumCapacity": 150
-  },
-  {
-    "Name": "Pattern Epsilon Obelisk Data",
-    "Rarity": "VeryRare",
-    "FormattedName": "ancienttechnologicaldata",
-    "Kind": "Data",
-    "OriginDetails": [
-      "Ancient/Guardian ruins"
-    ],
-    "Group": "Guardian",
-    "MaximumCapacity": 150
-  },
-  {
-    "Name": "Pattern Gamma Obelisk Data",
-    "Rarity": "VeryCommon",
-    "FormattedName": "ancienthistoricaldata",
-    "Kind": "Data",
-    "OriginDetails": [
-      "Ancient/Guardian ruins"
-    ],
-    "Group": "Guardian",
-    "MaximumCapacity": 150
-  },
+	{
+		"Name": "Pattern Beta Obelisk Data",
+		"Rarity": "Common",
+		"FormattedName": "ancientculturaldata",
+		"Kind": "Data",
+		"OriginDetails": [
+			"Ancient/Guardian ruins"
+		],
+		"Group": "GuardianRuins",
+		"MaximumCapacity": 150
+	},
+	{
+		"Name": "Pattern Delta Obelisk Data",
+		"Rarity": "Rare",
+		"FormattedName": "ancientlanguagedata",
+		"Kind": "Data",
+		"OriginDetails": [
+			"Ancient/Guardian ruins"
+		],
+		"Group": "GuardianRuins",
+		"MaximumCapacity": 150
+	},
+	{
+		"Name": "Pattern Epsilon Obelisk Data",
+		"Rarity": "VeryRare",
+		"FormattedName": "ancienttechnologicaldata",
+		"Kind": "Data",
+		"OriginDetails": [
+			"Ancient/Guardian ruins"
+		],
+		"Group": "GuardianRuins",
+		"MaximumCapacity": 150
+	},
+	{
+		"Name": "Pattern Gamma Obelisk Data",
+		"Rarity": "VeryCommon",
+		"FormattedName": "ancienthistoricaldata",
+		"Kind": "Data",
+		"OriginDetails": [
+			"Ancient/Guardian ruins"
+		],
+		"Group": "GuardianRuins",
+		"MaximumCapacity": 150
+	},
   {
     "Name": "Peculiar Shield Frequency Data",
     "Rarity": "VeryRare",
@@ -1473,7 +1473,7 @@
     "OriginDetails": [
       "Ship scanning (Thargoid interceptors)"
     ],
-    "Group": "Thargoid"
+    "Group": "ThargoidShip"
   },
   {
     "Name": "Meta-alloys",
@@ -1576,17 +1576,18 @@
       "Needed for Didi Vatermann (25)"
     ]
   },
-  {
-    "Name": "Sensor Fragment",
-    "Rarity": "VeryRare",
-    "FormattedName": "unknownenergysource",
-    "Kind": "Material",
-    "Subkind": "Manufactured",
-    "OriginDetails": [
-      "Destroyed Unknown Artefact",
-      "Needed for Professor Palin (25)"
-    ]
-  },
+	{
+		"Name": "Sensor Fragment",
+		"Rarity": "VeryRare",
+		"FormattedName": "unknownenergysource",
+		"Kind": "Material",
+		"Subkind": "Manufactured",
+		"OriginDetails": [
+			"Thargoid Scavengers, Destroyed Thargoid Sensor",
+			"Needed for Professor Palin (25)"
+		],
+		"Group": "ThargoidSite"
+	},
   {
     "Name": "Kongga Ale",
     "Rarity": "None",
@@ -1645,7 +1646,7 @@
     "OriginDetails": [
       "Base scanning (Thargoid uplink devices)"
     ],
-    "Group": "Thargoid"
+    "Group": "ThargoidSite"
   },
   {
     "Name": "Thargoid Residue Data",
@@ -1655,7 +1656,7 @@
     "OriginDetails": [
       "Base scanning (Thargoid uplink devices)"
     ],
-    "Group": "Thargoid"
+    "Group": "ThargoidSite"
   },
   {
     "Name": "Thargoid Structural Data",
@@ -1665,7 +1666,7 @@
     "OriginDetails": [
       "Base scanning (Thargoid uplink devices)"
     ],
-    "Group": "Thargoid"
+    "Group": "ThargoidSite"
   },
   {
     "Name": "Thargoid Carapace",
@@ -1676,7 +1677,7 @@
     "OriginDetails": [
       "Thargoid scavengers"
     ],
-    "Group": "Thargoid"
+    "Group": "ThargoidSite"
   },
   {
     "Name": "Thargoid Energy Cell",
@@ -1687,7 +1688,7 @@
     "OriginDetails": [
       "Thargoid scavengers"
     ],
-    "Group": "Thargoid"
+    "Group": "ThargoidSite"
   },
   {
     "Name": "Thargoid Organic Circuitry",
@@ -1698,7 +1699,7 @@
     "OriginDetails": [
       "Thargoid scavengers"
     ],
-    "Group": "Thargoid"
+    "Group": "ThargoidSite"
   },
   {
     "Name": "Thargoid Technological Components",
@@ -1709,7 +1710,7 @@
     "OriginDetails": [
       "Thargoid scavengers"
     ],
-    "Group": "Thargoid"
+    "Group": "ThargoidSite"
   },
   {
     "Name": "Thargoid Wake Data",
@@ -1719,7 +1720,7 @@
     "OriginDetails": [
       "High wake scanning (Thargoid interceptors)"
     ],
-    "Group": "Thargoid"
+    "Group": "ThargoidShip"
   },
   {
     "Name": "Ship Flight Data",
@@ -1729,7 +1730,7 @@
     "OriginDetails": [
       "Ship scanning (Thargoid interceptors)"
     ],
-    "Group": "Thargoid"
+    "Group": "ThargoidShip"
   },
   {
     "Name": "Ship System Data",
@@ -1739,7 +1740,7 @@
     "OriginDetails": [
       "Ship scanning (Thargoid interceptors)"
     ],
-    "Group": "Thargoid"
+    "Group": "ThargoidShip"
   },
   {
     "Name": "Wreckage Components",
@@ -1750,7 +1751,7 @@
     "OriginDetails": [
       "Ship salvage (Thargoid ships)"
     ],
-    "Group": "Thargoid"
+    "Group": "ThargoidShip"
   },
   {
     "Name": "Bio-Mechanical Conduits",
@@ -1761,7 +1762,7 @@
     "OriginDetails": [
       "Ship salvage (Thargoid ships)"
     ],
-    "Group": "Thargoid"
+    "Group": "ThargoidShip"
   },
   {
     "Name": "Weapon Parts",
@@ -1772,7 +1773,7 @@
     "OriginDetails": [
       "Ship salvage (Thargoid ships)"
     ],
-    "Group": "Thargoid"
+    "Group": "ThargoidShip"
   },
   {
     "Name": "Propulsion Elements",
@@ -1783,7 +1784,7 @@
     "OriginDetails": [
       "Ship salvage (Thargoid ships)"
     ],
-    "Group": "Thargoid"
+    "Group": "ThargoidShip"
   },
   {
     "Name": "Guardian Weapon Blueprint Segment",
@@ -1793,83 +1794,83 @@
     "OriginDetails": [
       "Ancient/Guardian ruins"
     ],
-    "Group": "Guardian",
+    "Group": "GuardianRuinsActive",
     "MaximumCapacity": 150
   },
-  {
-    "Name": "Guardian Power Cell",
-    "Rarity": "VeryCommon",
-    "FormattedName": "guardian_powercell",
-    "Kind": "Material",
-    "Subkind": "Manufactured",
-    "OriginDetails": [
-      "Ancient/Guardian ruins"
-    ],
-    "Group": "Guardian"
-  },
-  {
-    "Name": "Guardian Technology Component",
-    "Rarity": "Standard",
-    "FormattedName": "guardian_techcomponent",
-    "Kind": "Material",
-    "Subkind": "Manufactured",
-    "OriginDetails": [
-      "Ancient/Guardian ruins"
-    ],
-    "Group": "Guardian"
-  },
-  {
-    "Name": "Guardian Power Conduit",
-    "Rarity": "Common",
-    "FormattedName": "guardian_powerconduit",
-    "Kind": "Material",
-    "Subkind": "Manufactured",
-    "OriginDetails": [
-      "Ancient/Guardian ruins"
-    ],
-    "Group": "Guardian"
-  },
-  {
-    "Name": "Guardian Sentinel Weapon Parts",
-    "Rarity": "Standard",
-    "FormattedName": "guardian_sentinel_weaponparts",
-    "Kind": "Material",
-    "Subkind": "Manufactured",
-    "OriginDetails": [
-      "Ancient/Guardian ruins"
-    ],
-    "Group": "Guardian"
-  },
-  {
-    "Name": "Guardian Module Blueprint Segment",
-    "Rarity": "VeryRare",
-    "FormattedName": "guardian_moduleblueprint",
-    "Kind": "Data",
-    "OriginDetails": [
-      "Ancient/Guardian ruins"
-    ],
-    "Group": "Guardian",
-    "MaximumCapacity": 150
-  },
-  {
-    "Name": "Guardian Wreckage Components",
-    "Rarity": "VeryCommon",
-    "FormattedName": "guardian_sentinel_wreckagecomponents",
-    "Kind": "Material",
-    "Subkind": "Manufactured",
-    "OriginDetails": [
-      "Ancient/Guardian ruins"
-    ],
-    "Group": "Guardian"
-  },
-  {
-    "Name": "Guardian Vessel Blueprint Segment",
-    "Rarity": "VeryRare",
-    "FormattedName": "guardian_vesselblueprint",
-    "Kind": "Data",
-    "OriginDetails": [
-      "Ancient/Guardian ruins"
-    ],
-    "Group": "Guardian"
-  }
+	{
+		"Name": "Guardian Power Cell",
+		"Rarity": "VeryCommon",
+		"FormattedName": "guardian_powercell",
+		"Kind": "Material",
+		"Subkind": "Manufactured",
+		"OriginDetails": [
+			"Ancient/Guardian ruins"
+		],
+		"Group": "GuardianRuinsActive"
+	},
+	{
+		"Name": "Guardian Technology Component",
+		"Rarity": "Standard",
+		"FormattedName": "guardian_techcomponent",
+		"Kind": "Material",
+		"Subkind": "Manufactured",
+		"OriginDetails": [
+			"Ancient/Guardian ruins"
+		],
+		"Group": "GuardianRuinsActive"
+	},
+	{
+		"Name": "Guardian Power Conduit",
+		"Rarity": "Common",
+		"FormattedName": "guardian_powerconduit",
+		"Kind": "Material",
+		"Subkind": "Manufactured",
+		"OriginDetails": [
+			"Ancient/Guardian ruins"
+		],
+		"Group": "GuardianRuinsActive"
+	},
+	{
+		"Name": "Guardian Sentinel Weapon Parts",
+		"Rarity": "Standard",
+		"FormattedName": "guardian_sentinel_weaponparts",
+		"Kind": "Material",
+		"Subkind": "Manufactured",
+		"OriginDetails": [
+			"Ancient/Guardian ruins"
+		],
+		"Group": "GuardianRuinsActive"
+	},
+	{
+		"Name": "Guardian Module Blueprint Segment",
+		"Rarity": "VeryRare",
+		"FormattedName": "guardian_moduleblueprint",
+		"Kind": "Data",
+		"OriginDetails": [
+			"Ancient/Guardian ruins"
+		],
+		"Group": "GuardianRuinsActive",
+		"MaximumCapacity": 150
+	},
+	{
+		"Name": "Guardian Wreckage Components",
+		"Rarity": "VeryCommon",
+		"FormattedName": "guardian_sentinel_wreckagecomponents",
+		"Kind": "Material",
+		"Subkind": "Manufactured",
+		"OriginDetails": [
+			"Ancient/Guardian ruins"
+		],
+		"Group": "GuardianRuinsActive"
+	},
+	{
+		"Name": "Guardian Vessel Blueprint Segment",
+		"Rarity": "VeryRare",
+		"FormattedName": "guardian_vesselblueprint",
+		"Kind": "Data",
+		"OriginDetails": [
+			"Ancient/Guardian ruins"
+		],
+		"Group": "GuardianRuinsActive"
+	}
 ]

--- a/EDEngineer/Resources/Data/localization.json
+++ b/EDEngineer/Resources/Data/localization.json
@@ -41,5470 +41,5506 @@
       "NotReadyWarning": "Tento překlad není kompletní. Pokud si ho zvolíte, počítejte s tím, že ne všechno musí být přeloženo. To co přeloženo nebude, bude nadále v angličtině."
     }
   },
-  "Translations": {
-    "Short Range Blaster": {
-      "es": "Destructor de Corto Alcance",
-      "pt": "Disparo de Curto Alcance",
-      "de": "Kurzdistanzblaster",
-      "fr": "Tir à Courte Portée",
-      "ru": "Бластер малого радиуса",
-      "pl": "Short Range Blaster",
-      "cs": "Short Range Blaster"
-    },
-    "Lightweight": {
-      "es": "Aligerado",
-      "pt": "Leve",
-      "de": "Leicht",
-      "fr": "Léger",
-      "ru": "Облегченный",
-      "pl": "Lightweight",
-      "cs": "Lightweight"
-    },
-    "Heavy Duty Hull Reinforcement": {
-      "es": "Refuerzo Estructural de Alta Resistencia",
-      "pt": "Reforço de Casco Pesado",
-      "de": "Schwere Rumpfhüllenverstärkung",
-      "fr": "Renforts de coque lourd",
-      "ru": "Утяжеление усилителя корпуса",
-      "pl": "Heavy Duty Hull Reinforcement",
-      "cs": "Heavy Duty Hull Reinforcement"
-    },
-    "Drive Strengthening": {
-      "es": "Fortalecimiento de Motor",
-      "pt": "Reforçamento do Motor",
-      "de": "Antriebsstärkung",
-      "fr": "Renforcement du réacteur",
-      "ru": "Защищённый двигатель",
-      "pl": "Drive Strengthening",
-      "cs": "Drive Strengthening"
-    },
-    "Efficient Weapon": {
-      "es": "Arma Eficiente",
-      "pt": "Arma Eficiente",
-      "de": "Waffeneffizienz",
-      "fr": "Arme efficace",
-      "ru": "Эффективное оружие",
-      "pl": "Efficient Weapon",
-      "cs": "Efficient Weapon"
-    },
-    "Lightweight Mount": {
-      "es": "Anclaje Ligero",
-      "pt": "Encaixe Leve",
-      "de": "Leichtgewichtgeschütz",
-      "fr": "Support léger",
-      "ru": "Легкое крепление",
-      "pl": "Lightweight Mount",
-      "cs": "Lightweight Mount"
-    },
-    "Armoured": {
-      "es": "Blindado",
-      "pt": "Blindado",
-      "de": "Gepanzert",
-      "fr": "Blindé",
-      "ru": "Бронированный",
-      "pl": "Armoured",
-      "cs": "Armoured"
-    },
-    "Reinforced": {
-      "es": "Reforzado",
-      "pt": "Reforçado",
-      "de": "Verstärkt",
-      "fr": "Renforcé",
-      "ru": "Усиленный",
-      "pl": "Reinforced",
-      "cs": "Reinforced"
-    },
-    "Sturdy Mount": {
-      "es": "Anclaje Robusto",
-      "pt": "Encaixe Robusto",
-      "de": "Robustes Gestell",
-      "fr": "Support robuste",
-      "ru": "Прочное крепление",
-      "pl": "Sturdy Mount",
-      "cs": "Sturdy Mount"
-    },
-    "Longer Range FSD interdictor": {
-      "es": "Interdictor de MDD de Largo Alcance",
-      "pt": "Interditor de MDD de Longo Alcance",
-      "de": "Langstrecken-FSA-Unterbrecher",
-      "fr": "Intercepteur FSD longue portée",
-      "ru": "Увеличение дальности перехвата",
-      "pl": "Longer Range FSD interdictor",
-      "cs": "Longer Range FSD interdictor"
-    },
-    "Reinforced Shields": {
-      "es": "Escudos Reforzados",
-      "pt": "Escudos Reforçados",
-      "de": "Verstärkte Schilde",
-      "fr": "Bouclier renforcé",
-      "ru": "Усиленный щит",
-      "pl": "Reinforced Shields",
-      "cs": "Reinforced Shields"
-    },
-    "Enhanced, Low Power Shields": {
-      "es": "Escudos Mejorados de Baja Energía",
-      "pt": "Escudos de Baixo Consumo, Aprimorados",
-      "de": "Verbesserte Niedrigenergieschilde",
-      "fr": "Boucliers amélioré à consommation réduite",
-      "ru": "Энергосберегающий щит",
-      "pl": "Enhanced, Low Power Shields",
-      "cs": "Enhanced, Low Power Shields"
-    },
-    "Shielded": {
-      "es": "Blindado",
-      "pt": "Blindado",
-      "de": "Abgeschirmt",
-      "fr": "Renforcé",
-      "ru": "Бронированный",
-      "pl": "Shielded",
-      "cs": "Shielded"
-    },
-    "Thermal Resistant": {
-      "es": "Resistencia Térmica",
-      "pt": "Resistência Térmica",
-      "de": "Thermalresistent",
-      "fr": "Résistance thermique",
-      "ru": "Противотепловое усиление",
-      "pl": "Thermal Resistant",
-      "cs": "Thermal Resistant"
-    },
-    "Weapon Focused": {
-      "es": "Orientado a Armas",
-      "pt": "Foco nas Armas",
-      "de": "Waffenfokussiert",
-      "fr": "Optimisé armes",
-      "ru": "Оружие-ориентированный",
-      "pl": "Weapon Focused",
-      "cs": "Weapon Focused"
-    },
-    "Blast Resistant": {
-      "es": "Blindaje Resistente a Explosiones",
-      "pt": "Resistente à Explosão",
-      "de": "Detonationsresistent",
-      "fr": "Anti-explosion",
-      "ru": "Противовзрывное усиление",
-      "pl": "Blast Resistant",
-      "cs": "Blast Resistant"
-    },
-    "High Capacity Magazine": {
-      "es": "Cargador de Alta Capacidad",
-      "pt": "Cartucho de Alta Capacidade",
-      "de": "Hochleistungsmagazin",
-      "fr": "Chargeur grande capacité",
-      "ru": "Вместительный магазин",
-      "pl": "High Capacity Magazine",
-      "cs": "High Capacity Magazine"
-    },
-    "Kinetic Resistant": {
-      "es": "Resistencia Cinética",
-      "pt": "Resistência Cinética",
-      "de": "Kinetikresistent",
-      "fr": "Résistance cinétique",
-      "ru": "Противокинетическое усиление",
-      "pl": "Kinetic Resistant",
-      "cs": "Kinetic Resistant"
-    },
-    "Focused Weapon": {
-      "es": "Arma Concentrada",
-      "pt": "Arma com Foco",
-      "de": "Waffenfokus",
-      "fr": "Arme concentrée",
-      "ru": "Сфокусированное оружие",
-      "pl": "Focused Weapon",
-      "cs": "Focused Weapon"
-    },
-    "Thermal Resistant Shields": {
-      "es": "Escudos de Resistencia Térmica",
-      "pt": "Escudos de Resistência Térmica",
-      "de": "Thermalresistente Schilde",
-      "fr": "Bouclier à résistance thermique",
-      "ru": "Противотепловой щит",
-      "pl": "Thermal Resistant Shields",
-      "cs": "Thermal Resistant Shields"
-    },
-    "Rapid Fire Modification": {
-      "es": "Modificación de Tiro Rápido",
-      "pt": "Modificação de Disparo Rápido",
-      "de": "Schnellfeuermodifikation",
-      "fr": "Modification cadence rapide",
-      "ru": "Увеличение скорострельности",
-      "pl": "Rapid Fire Modification",
-      "cs": "Rapid Fire Modification"
-    },
-    "Long Range Weapon": {
-      "es": "Arma de Largo Alcance",
-      "pt": "Arma de Longo Alcance",
-      "de": "Langstreckenwaffe",
-      "fr": "Armes à longue portée",
-      "ru": "Увеличенная дальность",
-      "pl": "Long Range Weapon",
-      "cs": "Long Range Weapon"
-    },
-    "Ammo Capacity": {
-      "es": "Capacidad de Munición",
-      "pt": "Capacidade de Munição",
-      "de": "Munitionskapazität",
-      "fr": "capacité de munition",
-      "ru": "Боезапас",
-      "pl": "Ammo Capacity",
-      "cs": "Ammo Capacity"
-    },
-    "Overcharged Weapon": {
-      "es": "Arma Sobrecargada",
-      "pt": "Arma Sobrecarregada",
-      "de": "Überladungswaffe",
-      "fr": "Arme surchargée",
-      "ru": "Усиленное оружие",
-      "pl": "Overcharged Weapon",
-      "cs": "Overcharged Weapon"
-    },
-    "Low Emissions": {
-      "es": "Bajas Emisiones",
-      "pt": "Baixa Emissão",
-      "de": "Emissionsoptimiert",
-      "fr": "Basse émission",
-      "ru": "Снижение излучения",
-      "pl": "Low Emissions",
-      "cs": "Low Emissions"
-    },
-    "System Focused": {
-      "es": "Orientado a Sistemas",
-      "pt": "Foco nos Sistemas",
-      "de": "Systemfokussiert",
-      "fr": "Optimisé systèmes",
-      "ru": "Системо-ориентированный",
-      "pl": "System Focused",
-      "cs": "System Focused"
-    },
-    "Overcharged": {
-      "es": "Sobrecargado",
-      "pt": "Sobrecarregado",
-      "de": "Überladungs",
-      "fr": "Surchargé",
-      "ru": "Усиленный",
-      "pl": "Overcharged",
-      "cs": "Overcharged"
-    },
-    "Increased FSD Range": {
-      "es": "Aumento de Alcance de MDD",
-      "pt": "Alcance do MDD Aumentado",
-      "de": "Erhöhte FSA-Reichweite",
-      "fr": "Portée FSD améliorée",
-      "ru": "Увеличенная дальность FSD",
-      "pl": "Increased FSD Range",
-      "cs": "Increased FSD Range"
-    },
-    "Thermal Resistant Hull Reinforcement": {
-      "es": "Refuerzo Estructural de Resistencia Térmica",
-      "pt": "Reforço de Casco Resistência Térmica",
-      "de": "Thermalresistente Rumpfhüllenverstärkung",
-      "fr": "Renforts de coque antithermique",
-      "ru": "Противотепловое усиление",
-      "pl": "Thermal Resistant Hull Reinforcement",
-      "cs": "Thermal Resistant Hull Reinforcement"
-    },
-    "Dirty Drive Tuning": {
-      "es": "Modificación de Motor Sucio",
-      "pt": "Ajuste de Motor Sujo",
-      "de": "Aggressives Antriebstuning",
-      "fr": "Optimisation de réacteur détériorante",
-      "ru": "«Грязная» донастройка",
-      "pl": "Dirty Drive Tuning",
-      "cs": "Dirty Drive Tuning"
-    },
-    "Engine Focused": {
-      "es": "Orientado a Motor",
-      "pt": "Foco nos Motores",
-      "de": "Antriebsfokussiert",
-      "fr": "Optimisé moteur",
-      "ru": "Двигатель-ориентированный",
-      "pl": "Engine Focused",
-      "cs": "Engine Focused"
-    },
-    "Kinetic Resistant Hull Reinforcement": {
-      "es": "Refuerzo Estructural de Resistencia Cinética",
-      "pt": "Reforço de Casco Resistência Cinética",
-      "de": "Kinetikresistente Rumpfhüllenverstärkung",
-      "fr": "Renforts de coque anti-cinétique",
-      "ru": "Противокинетическое усиление",
-      "pl": "Kinetic Resistant Hull Reinforcement",
-      "cs": "Kinetic Resistant Hull Reinforcement"
-    },
-    "High Charge Capacity": {
-      "es": "Alta Capacidad de Carga",
-      "pt": "Alta Capacidade de Carga",
-      "de": "Hochleistungsfähig",
-      "fr": "Capacité Surchargée",
-      "ru": "Высокоёмкий",
-      "pl": "High Charge Capacity",
-      "cs": "High Charge Capacity"
-    },
-    "Rapid Charge": {
-      "es": "Recarga Rápida",
-      "pt": "Carga Rápida",
-      "de": "Ladungsoptimiert",
-      "fr": "Chargement rapide",
-      "ru": "Быстрозаряжающийся",
-      "pl": "Rapid Charge",
-      "cs": "Rapid Charge"
-    },
-    "Expanded FSD Interdictor Capture Arc": {
-      "es": "Arco de Captura de Interdictor de MDD Extendido",
-      "pt": "Arco de Captura do Interditor de MDD Expandido",
-      "de": "Weitwinkel-FSA-Unterbrecher",
-      "fr": "Intercepteur FSD à angle de capture augmenté",
-      "ru": "Увеличение угла перехвата",
-      "pl": "Expanded FSD Interdictor Capture Arc",
-      "cs": "Expanded FSD Interdictor Capture Arc"
-    },
-    "Heavy Duty": {
-      "es": "Alta Resistencia",
-      "pt": "Alta Resistência",
-      "de": "Schwer",
-      "fr": "Renforts de coque lourd",
-      "ru": "Усиленный",
-      "pl": "Heavy Duty",
-      "cs": "Heavy Duty"
-    },
-    "Charge Enhanced": {
-      "es": "Carga Mejorada",
-      "pt": "Recarga Melhorada",
-      "de": "Ladungsoptimiert",
-      "fr": "Répartiteur de puissance rapide",
-      "ru": "Быстрозарядный",
-      "pl": "Charge Enhanced",
-      "cs": "Charge Enhanced"
-    },
-    "Blast Resistant Hull Reinforcement": {
-      "es": "Refuerzo Estructural de Resistencia Explosiva",
-      "pt": "Reforço de Casco Resistente à Explosão",
-      "de": "Detonationsresistente Rumpfhüllenverstärkung",
-      "fr": "Renforts de coque anti-explosion",
-      "ru": "Противовзрывное усиление корпуса",
-      "pl": "Blast Resistant Hull Reinforcement",
-      "cs": "Blast Resistant Hull Reinforcement"
-    },
-    "Double Shot": {
-      "es": "Doble Disparo",
-      "pt": "Tiro Duplo",
-      "de": "Doppelschuss",
-      "fr": "Double Tir",
-      "ru": "Двойной выстрел",
-      "pl": "Double Shot",
-      "cs": "Double Shot"
-    },
-    "Lightweight Hull Reinforcement": {
-      "es": "Refuerzo Estructural Aligerado",
-      "pt": "Reforço de Casco Leve",
-      "de": "Leichte Rumpfhüllenverstärkung",
-      "fr": "Renforcement de coque Léger",
-      "ru": "Облегчение усилителя корпуса",
-      "pl": "Lightweight Hull Reinforcement",
-      "cs": "Lightweight Hull Reinforcement"
-    },
-    "Resistance Augmented": {
-      "es": "Resistencia Aumentada",
-      "pt": "Resistência Aumentada",
-      "de": "Widerstandsverstärkt",
-      "fr": "Résistances Augmentés",
-      "ru": "Сбалансированное усиление",
-      "pl": "Resistance Augmented",
-      "cs": "Resistance Augmented"
-    },
-    "Specialised": {
-      "es": "Especializado",
-      "pt": "Especializado",
-      "de": "Spezialisiert",
-      "fr": "Specialisé",
-      "ru": "Специализированный",
-      "pl": "Specialised",
-      "cs": "Specialised"
-    },
-    "Faster FSD Boot Sequence": {
-      "es": "Secuencia de Inicio de MDD Rápida",
-      "pt": "Sequência de Inicialização do MDD Mais Rápida",
-      "de": "Schnellere FSA-Ladesequenz",
-      "fr": "Chargement FSD acceleré",
-      "ru": "Ускорение перезапуска FSD",
-      "pl": "Faster FSD Boot Sequence",
-      "cs": "Faster FSD Boot Sequence"
-    },
-    "Shielded FSD": {
-      "es": "MDD Blindado",
-      "pt": "MDD Protegido",
-      "de": "Abgeschirmter FSA",
-      "fr": "FSD Renforcé",
-      "ru": "Защищенный FSD",
-      "pl": "Shielded FSD",
-      "cs": "Shielded FSD"
-    },
-    "Clean Drive Tuning": {
-      "es": "Modificación de Motor Limpio",
-      "pt": "Ajuste de Motor Limpo",
-      "de": "Ausgewogenes Antriebstuning",
-      "fr": "Optimisation de réacteur propre",
-      "ru": "«Чистая» донастройка",
-      "pl": "Clean Drive Tuning",
-      "cs": "Clean Drive Tuning"
-    },
-    "Kinetic Resistant Shields": {
-      "es": "Escudos de Resistencia Cinética",
-      "pt": "Escudos com Resistência Cinética",
-      "de": "Kinetikresistente Schilde",
-      "fr": "Bouclier à résistance Cinétique",
-      "ru": "Противокинетический щит",
-      "pl": "Kinetic Resistant Shields",
-      "cs": "Kinetic Resistant Shields"
-    },
-    "Plasma Accelerator": {
-      "es": "Acelerador de Plasma",
-      "pt": "Acelerador de Plasma",
-      "de": "Plasmabeschleuniger",
-      "fr": "Accelerateur à Plasma",
-      "ru": "Ускоритель плазмы",
-      "pl": "Plasma Accelerator",
-      "cs": "Plasma Accelerator"
-    },
-    "Electronic Countermeasure": {
-      "es": "Contramedida Electrónica",
-      "pt": "Contramedida Eletrônica",
-      "de": "Elektronische Gegenmaßnahmen",
-      "fr": "CME",
-      "ru": "Электронное противодействие",
-      "pl": "Electronic Countermeasure",
-      "cs": "Electronic Countermeasure"
-    },
-    "Life Support": {
-      "es": "Soporte Vital",
-      "pt": "Suporte Vital",
-      "de": "Lebenserhaltung",
-      "fr": "Systèmes de Survie",
-      "ru": "Система жизнеобеспечения",
-      "pl": "Life Support",
-      "cs": "Life Support"
-    },
-    "Hull Reinforcement Package": {
-      "es": "Paquete de Refuerzo Estructural",
-      "pt": "Pacote de Reforços de Casco de Meta Liga",
-      "de": "Rumpfhüllenverstärkung",
-      "fr": "Renforts de coque",
-      "ru": "Набор для усиления корпуса",
-      "pl": "Hull Reinforcement Package",
-      "cs": "Hull Reinforcement Package"
+	"Translations": {
+		"Short Range Blaster": {
+			"es": "Destructor de Corto Alcance",
+			"pt": "Disparo de Curto Alcance",
+			"de": "Kurzdistanzblaster",
+			"fr": "Tir à Courte Portée",
+			"ru": "Бластер малого радиуса",
+			"pl": "Short Range Blaster",
+			"cs": "Short Range Blaster"
+		},
+		"Lightweight": {
+			"es": "Aligerado",
+			"pt": "Leve",
+			"de": "Leicht",
+			"fr": "Léger",
+			"ru": "Облегченный",
+			"pl": "Lightweight",
+			"cs": "Lightweight"
+		},
+		"Heavy Duty Hull Reinforcement": {
+			"es": "Refuerzo Estructural de Alta Resistencia",
+			"pt": "Reforço de Casco Pesado",
+			"de": "Schwere Rumpfhüllenverstärkung",
+			"fr": "Renforts de coque lourd",
+			"ru": "Утяжеление усилителя корпуса",
+			"pl": "Heavy Duty Hull Reinforcement",
+			"cs": "Heavy Duty Hull Reinforcement"
+		},
+		"Drive Strengthening": {
+			"es": "Fortalecimiento de Motor",
+			"pt": "Reforçamento do Motor",
+			"de": "Antriebsstärkung",
+			"fr": "Renforcement du réacteur",
+			"ru": "Защищённый двигатель",
+			"pl": "Drive Strengthening",
+			"cs": "Drive Strengthening"
+		},
+		"Efficient Weapon": {
+			"es": "Arma Eficiente",
+			"pt": "Arma Eficiente",
+			"de": "Waffeneffizienz",
+			"fr": "Arme efficace",
+			"ru": "Эффективное оружие",
+			"pl": "Efficient Weapon",
+			"cs": "Efficient Weapon"
+		},
+		"Lightweight Mount": {
+			"es": "Anclaje Ligero",
+			"pt": "Encaixe Leve",
+			"de": "Leichtgewichtgeschütz",
+			"fr": "Support léger",
+			"ru": "Легкое крепление",
+			"pl": "Lightweight Mount",
+			"cs": "Lightweight Mount"
+		},
+		"Armoured": {
+			"es": "Blindado",
+			"pt": "Blindado",
+			"de": "Gepanzert",
+			"fr": "Blindé",
+			"ru": "Бронированный",
+			"pl": "Armoured",
+			"cs": "Armoured"
+		},
+		"Reinforced": {
+			"es": "Reforzado",
+			"pt": "Reforçado",
+			"de": "Verstärkt",
+			"fr": "Renforcé",
+			"ru": "Усиленный",
+			"pl": "Reinforced",
+			"cs": "Reinforced"
+		},
+		"Sturdy Mount": {
+			"es": "Anclaje Robusto",
+			"pt": "Encaixe Robusto",
+			"de": "Robustes Gestell",
+			"fr": "Support robuste",
+			"ru": "Прочное крепление",
+			"pl": "Sturdy Mount",
+			"cs": "Sturdy Mount"
+		},
+		"Longer Range FSD interdictor": {
+			"es": "Interdictor de MDD de Largo Alcance",
+			"pt": "Interditor de MDD de Longo Alcance",
+			"de": "Langstrecken-FSA-Unterbrecher",
+			"fr": "Intercepteur FSD longue portée",
+			"ru": "Увеличение дальности перехвата",
+			"pl": "Longer Range FSD interdictor",
+			"cs": "Longer Range FSD interdictor"
+		},
+		"Reinforced Shields": {
+			"es": "Escudos Reforzados",
+			"pt": "Escudos Reforçados",
+			"de": "Verstärkte Schilde",
+			"fr": "Bouclier renforcé",
+			"ru": "Усиленный щит",
+			"pl": "Reinforced Shields",
+			"cs": "Reinforced Shields"
+		},
+		"Enhanced, Low Power Shields": {
+			"es": "Escudos Mejorados de Baja Energía",
+			"pt": "Escudos de Baixo Consumo, Aprimorados",
+			"de": "Verbesserte Niedrigenergieschilde",
+			"fr": "Boucliers amélioré à consommation réduite",
+			"ru": "Энергосберегающий щит",
+			"pl": "Enhanced, Low Power Shields",
+			"cs": "Enhanced, Low Power Shields"
+		},
+		"Shielded": {
+			"es": "Blindado",
+			"pt": "Blindado",
+			"de": "Abgeschirmt",
+			"fr": "Renforcé",
+			"ru": "Бронированный",
+			"pl": "Shielded",
+			"cs": "Shielded"
+		},
+		"Thermal Resistant": {
+			"es": "Resistencia Térmica",
+			"pt": "Resistência Térmica",
+			"de": "Thermalresistent",
+			"fr": "Résistance thermique",
+			"ru": "Противотепловое усиление",
+			"pl": "Thermal Resistant",
+			"cs": "Thermal Resistant"
+		},
+		"Weapon Focused": {
+			"es": "Orientado a Armas",
+			"pt": "Foco nas Armas",
+			"de": "Waffenfokussiert",
+			"fr": "Optimisé armes",
+			"ru": "Оружие-ориентированный",
+			"pl": "Weapon Focused",
+			"cs": "Weapon Focused"
+		},
+		"Blast Resistant": {
+			"es": "Blindaje Resistente a Explosiones",
+			"pt": "Resistente à Explosão",
+			"de": "Detonationsresistent",
+			"fr": "Anti-explosion",
+			"ru": "Противовзрывное усиление",
+			"pl": "Blast Resistant",
+			"cs": "Blast Resistant"
+		},
+		"High Capacity Magazine": {
+			"es": "Cargador de Alta Capacidad",
+			"pt": "Cartucho de Alta Capacidade",
+			"de": "Hochleistungsmagazin",
+			"fr": "Chargeur grande capacité",
+			"ru": "Вместительный магазин",
+			"pl": "High Capacity Magazine",
+			"cs": "High Capacity Magazine"
+		},
+		"Kinetic Resistant": {
+			"es": "Resistencia Cinética",
+			"pt": "Resistência Cinética",
+			"de": "Kinetikresistent",
+			"fr": "Résistance cinétique",
+			"ru": "Противокинетическое усиление",
+			"pl": "Kinetic Resistant",
+			"cs": "Kinetic Resistant"
+		},
+		"Focused Weapon": {
+			"es": "Arma Concentrada",
+			"pt": "Arma com Foco",
+			"de": "Waffenfokus",
+			"fr": "Arme concentrée",
+			"ru": "Сфокусированное оружие",
+			"pl": "Focused Weapon",
+			"cs": "Focused Weapon"
+		},
+		"Thermal Resistant Shields": {
+			"es": "Escudos de Resistencia Térmica",
+			"pt": "Escudos de Resistência Térmica",
+			"de": "Thermalresistente Schilde",
+			"fr": "Bouclier à résistance thermique",
+			"ru": "Противотепловой щит",
+			"pl": "Thermal Resistant Shields",
+			"cs": "Thermal Resistant Shields"
+		},
+		"Rapid Fire Modification": {
+			"es": "Modificación de Tiro Rápido",
+			"pt": "Modificação de Disparo Rápido",
+			"de": "Schnellfeuermodifikation",
+			"fr": "Modification cadence rapide",
+			"ru": "Увеличение скорострельности",
+			"pl": "Rapid Fire Modification",
+			"cs": "Rapid Fire Modification"
+		},
+		"Long Range Weapon": {
+			"es": "Arma de Largo Alcance",
+			"pt": "Arma de Longo Alcance",
+			"de": "Langstreckenwaffe",
+			"fr": "Armes à longue portée",
+			"ru": "Увеличенная дальность",
+			"pl": "Long Range Weapon",
+			"cs": "Long Range Weapon"
+		},
+		"Ammo Capacity": {
+			"es": "Capacidad de Munición",
+			"pt": "Capacidade de Munição",
+			"de": "Munitionskapazität",
+			"fr": "capacité de munition",
+			"ru": "Боезапас",
+			"pl": "Ammo Capacity",
+			"cs": "Ammo Capacity"
+		},
+		"Overcharged Weapon": {
+			"es": "Arma Sobrecargada",
+			"pt": "Arma Sobrecarregada",
+			"de": "Überladungswaffe",
+			"fr": "Arme surchargée",
+			"ru": "Усиленное оружие",
+			"pl": "Overcharged Weapon",
+			"cs": "Overcharged Weapon"
+		},
+		"Low Emissions": {
+			"es": "Bajas Emisiones",
+			"pt": "Baixa Emissão",
+			"de": "Emissionsoptimiert",
+			"fr": "Basse émission",
+			"ru": "Снижение излучения",
+			"pl": "Low Emissions",
+			"cs": "Low Emissions"
+		},
+		"System Focused": {
+			"es": "Orientado a Sistemas",
+			"pt": "Foco nos Sistemas",
+			"de": "Systemfokussiert",
+			"fr": "Optimisé systèmes",
+			"ru": "Системо-ориентированный",
+			"pl": "System Focused",
+			"cs": "System Focused"
+		},
+		"Overcharged": {
+			"es": "Sobrecargado",
+			"pt": "Sobrecarregado",
+			"de": "Überladungs",
+			"fr": "Surchargé",
+			"ru": "Усиленный",
+			"pl": "Overcharged",
+			"cs": "Overcharged"
+		},
+		"Increased FSD Range": {
+			"es": "Aumento de Alcance de MDD",
+			"pt": "Alcance do MDD Aumentado",
+			"de": "Erhöhte FSA-Reichweite",
+			"fr": "Portée FSD améliorée",
+			"ru": "Увеличенная дальность FSD",
+			"pl": "Increased FSD Range",
+			"cs": "Increased FSD Range"
+		},
+		"Thermal Resistant Hull Reinforcement": {
+			"es": "Refuerzo Estructural de Resistencia Térmica",
+			"pt": "Reforço de Casco Resistência Térmica",
+			"de": "Thermalresistente Rumpfhüllenverstärkung",
+			"fr": "Renforts de coque antithermique",
+			"ru": "Противотепловое усиление",
+			"pl": "Thermal Resistant Hull Reinforcement",
+			"cs": "Thermal Resistant Hull Reinforcement"
+		},
+		"Dirty Drive Tuning": {
+			"es": "Modificación de Motor Sucio",
+			"pt": "Ajuste de Motor Sujo",
+			"de": "Aggressives Antriebstuning",
+			"fr": "Optimisation de réacteur détériorante",
+			"ru": "«Грязная» донастройка",
+			"pl": "Dirty Drive Tuning",
+			"cs": "Dirty Drive Tuning"
+		},
+		"Engine Focused": {
+			"es": "Orientado a Motor",
+			"pt": "Foco nos Motores",
+			"de": "Antriebsfokussiert",
+			"fr": "Optimisé moteur",
+			"ru": "Двигатель-ориентированный",
+			"pl": "Engine Focused",
+			"cs": "Engine Focused"
+		},
+		"Kinetic Resistant Hull Reinforcement": {
+			"es": "Refuerzo Estructural de Resistencia Cinética",
+			"pt": "Reforço de Casco Resistência Cinética",
+			"de": "Kinetikresistente Rumpfhüllenverstärkung",
+			"fr": "Renforts de coque anti-cinétique",
+			"ru": "Противокинетическое усиление",
+			"pl": "Kinetic Resistant Hull Reinforcement",
+			"cs": "Kinetic Resistant Hull Reinforcement"
+		},
+		"High Charge Capacity": {
+			"es": "Alta Capacidad de Carga",
+			"pt": "Alta Capacidade de Carga",
+			"de": "Hochleistungsfähig",
+			"fr": "Capacité Surchargée",
+			"ru": "Высокоёмкий",
+			"pl": "High Charge Capacity",
+			"cs": "High Charge Capacity"
+		},
+		"Rapid Charge": {
+			"es": "Recarga Rápida",
+			"pt": "Carga Rápida",
+			"de": "Ladungsoptimiert",
+			"fr": "Chargement rapide",
+			"ru": "Быстрозаряжающийся",
+			"pl": "Rapid Charge",
+			"cs": "Rapid Charge"
+		},
+		"Expanded FSD Interdictor Capture Arc": {
+			"es": "Arco de Captura de Interdictor de MDD Extendido",
+			"pt": "Arco de Captura do Interditor de MDD Expandido",
+			"de": "Weitwinkel-FSA-Unterbrecher",
+			"fr": "Intercepteur FSD à angle de capture augmenté",
+			"ru": "Увеличение угла перехвата",
+			"pl": "Expanded FSD Interdictor Capture Arc",
+			"cs": "Expanded FSD Interdictor Capture Arc"
+		},
+		"Heavy Duty": {
+			"es": "Alta Resistencia",
+			"pt": "Alta Resistência",
+			"de": "Schwer",
+			"fr": "Renforts de coque lourd",
+			"ru": "Усиленный",
+			"pl": "Heavy Duty",
+			"cs": "Heavy Duty"
+		},
+		"Charge Enhanced": {
+			"es": "Carga Mejorada",
+			"pt": "Recarga Melhorada",
+			"de": "Ladungsoptimiert",
+			"fr": "Répartiteur de puissance rapide",
+			"ru": "Быстрозарядный",
+			"pl": "Charge Enhanced",
+			"cs": "Charge Enhanced"
+		},
+		"Blast Resistant Hull Reinforcement": {
+			"es": "Refuerzo Estructural de Resistencia Explosiva",
+			"pt": "Reforço de Casco Resistente à Explosão",
+			"de": "Detonationsresistente Rumpfhüllenverstärkung",
+			"fr": "Renforts de coque anti-explosion",
+			"ru": "Противовзрывное усиление корпуса",
+			"pl": "Blast Resistant Hull Reinforcement",
+			"cs": "Blast Resistant Hull Reinforcement"
+		},
+		"Double Shot": {
+			"es": "Doble Disparo",
+			"pt": "Tiro Duplo",
+			"de": "Doppelschuss",
+			"fr": "Double Tir",
+			"ru": "Двойной выстрел",
+			"pl": "Double Shot",
+			"cs": "Double Shot"
+		},
+		"Lightweight Hull Reinforcement": {
+			"es": "Refuerzo Estructural Aligerado",
+			"pt": "Reforço de Casco Leve",
+			"de": "Leichte Rumpfhüllenverstärkung",
+			"fr": "Renforcement de coque Léger",
+			"ru": "Облегчение усилителя корпуса",
+			"pl": "Lightweight Hull Reinforcement",
+			"cs": "Lightweight Hull Reinforcement"
+		},
+		"Resistance Augmented": {
+			"es": "Resistencia Aumentada",
+			"pt": "Resistência Aumentada",
+			"de": "Widerstandsverstärkt",
+			"fr": "Résistances Augmentés",
+			"ru": "Сбалансированное усиление",
+			"pl": "Resistance Augmented",
+			"cs": "Resistance Augmented"
+		},
+		"Specialised": {
+			"es": "Especializado",
+			"pt": "Especializado",
+			"de": "Spezialisiert",
+			"fr": "Specialisé",
+			"ru": "Специализированный",
+			"pl": "Specialised",
+			"cs": "Specialised"
+		},
+		"Faster FSD Boot Sequence": {
+			"es": "Secuencia de Inicio de MDD Rápida",
+			"pt": "Sequência de Inicialização do MDD Mais Rápida",
+			"de": "Schnellere FSA-Ladesequenz",
+			"fr": "Chargement FSD acceleré",
+			"ru": "Ускорение перезапуска FSD",
+			"pl": "Faster FSD Boot Sequence",
+			"cs": "Faster FSD Boot Sequence"
+		},
+		"Shielded FSD": {
+			"es": "MDD Blindado",
+			"pt": "MDD Protegido",
+			"de": "Abgeschirmter FSA",
+			"fr": "FSD Renforcé",
+			"ru": "Защищенный FSD",
+			"pl": "Shielded FSD",
+			"cs": "Shielded FSD"
+		},
+		"Clean Drive Tuning": {
+			"es": "Modificación de Motor Limpio",
+			"pt": "Ajuste de Motor Limpo",
+			"de": "Ausgewogenes Antriebstuning",
+			"fr": "Optimisation de réacteur propre",
+			"ru": "«Чистая» донастройка",
+			"pl": "Clean Drive Tuning",
+			"cs": "Clean Drive Tuning"
+		},
+		"Kinetic Resistant Shields": {
+			"es": "Escudos de Resistencia Cinética",
+			"pt": "Escudos com Resistência Cinética",
+			"de": "Kinetikresistente Schilde",
+			"fr": "Bouclier à résistance Cinétique",
+			"ru": "Противокинетический щит",
+			"pl": "Kinetic Resistant Shields",
+			"cs": "Kinetic Resistant Shields"
+		},
+		"Plasma Accelerator": {
+			"es": "Acelerador de Plasma",
+			"pt": "Acelerador de Plasma",
+			"de": "Plasmabeschleuniger",
+			"fr": "Accelerateur à Plasma",
+			"ru": "Ускоритель плазмы",
+			"pl": "Plasma Accelerator",
+			"cs": "Plasma Accelerator"
+		},
+		"Electronic Countermeasure": {
+			"es": "Contramedida Electrónica",
+			"pt": "Contramedida Eletrônica",
+			"de": "Elektronische Gegenmaßnahmen",
+			"fr": "CME",
+			"ru": "Электронное противодействие",
+			"pl": "Electronic Countermeasure",
+			"cs": "Electronic Countermeasure"
+		},
+		"Life Support": {
+			"es": "Soporte Vital",
+			"pt": "Suporte Vital",
+			"de": "Lebenserhaltung",
+			"fr": "Systèmes de Survie",
+			"ru": "Система жизнеобеспечения",
+			"pl": "Life Support",
+			"cs": "Life Support"
+		},
+		"Hull Reinforcement Package": {
+			"es": "Paquete de Refuerzo Estructural",
+			"pt": "Pacote de Reforços de Casco de Meta Liga",
+			"de": "Rumpfhüllenverstärkung",
+			"fr": "Renforts de coque",
+			"ru": "Набор для усиления корпуса",
+			"pl": "Hull Reinforcement Package",
+			"cs": "Hull Reinforcement Package"
 
-    },
-    "Cannon": {
-      "es": "Cañón",
-      "pt": "Canhão",
-      "de": "Kanone",
-      "fr": "Canon",
-      "ru": "Орудие",
-      "pl": "Cannon",
-      "cs": "Cannon"
-    },
-    "Thrusters": {
-      "es": "Impulsores",
-      "pt": "Propulsores",
-      "de": "Schubdüsen",
-      "fr": "Moteurs",
-      "ru": "Маневровые двигатели",
-      "pl": "Thrusters",
-      "cs": "Thrusters"
-    },
-    "Multi-cannon": {
-      "es": "Multicañón",
-      "pt": "Canhão de Repetição",
-      "de": "Mehrfachgeschütz",
-      "fr": "Multi-cannon",
-      "ru": "Многоствольное орудие",
-      "pl": "Multi-cannon",
-      "cs": "Multi-cannon"
-    },
-    "Missile Rack": {
-      "es": "Batería de Misiles",
-      "pt": "Estante de Mísseis",
-      "de": "Raketenrampe",
-      "fr": "Rack de Missiles",
-      "ru": "Ракетный лоток",
-      "pl": "Missile Rack",
-      "cs": "Missile Rack"
-    },
-    "Power Plant": {
-      "es": "Núcleo de Energía",
-      "pt": "Gerador de Energia",
-      "de": "Kraftwerk",
-      "fr": "Générateur",
-      "ru": "Силовая установка",
-      "pl": "Power Plant",
-      "cs": "Power Plant"
-    },
-    "Chaff Launcher": {
-      "es": "Lanzador de Señuelos",
-      "pt": "Lançador de Chaff",
-      "de": "Düppel-Werfer",
-      "fr": "Contre-Mesures",
-      "ru": "Разбрасыватель дип. отражателей",
-      "pl": "Chaff Launcher",
-      "cs": "Chaff Launcher"
-    },
-    "Frame Shift Drive Interdictor": {
-      "es": "Interdictor de MDD",
-      "pt": "Interditor de Motor de Distorção",
-      "de": "FSA-Unterbrecher",
-      "fr": "Interdicteur FSD",
-      "ru": "FSD перехватчик",
-      "pl": "Frame Shift Drive Interdictor",
-      "cs": "Frame Shift Drive Interdictor"
-    },
-    "Shield Generator": {
-      "es": "Generador de Escudos",
-      "pt": "Gerador de Escudo",
-      "de": "Schildgenerator",
-      "fr": "Générateur de Bouclier",
-      "ru": "Щитогенератор",
-      "pl": "Shield Generator",
-      "cs": "Shield Generator"
-    },
-    "Point Defence": {
-      "es": "Defensa de Punto",
-      "pt": "Defesa de Ponto",
-      "de": "Punktverteidigung",
-      "fr": "Défense ponctuelle",
-      "ru": "Точечная оборона",
-      "pl": "Point Defence",
-      "cs": "Point Defence"
-    },
-    "Shield Booster": {
-      "es": "Potenciador de Escudos",
-      "pt": "Potenciador de Escudo",
-      "de": "Schild-Booster",
-      "fr": "Survolteur de Bouclier",
-      "ru": "Усилитель щита",
-      "pl": "Shield Booster",
-      "cs": "Shield Booster"
-    },
-    "Kill Warrant Scanner": {
-      "es": "Escáner de Registro Criminal",
-      "pt": "Scanner de Registro Criminal",
-      "de": "Tötungsbefehl-Scanner",
-      "fr": "Scanner d'avis de recherches",
-      "ru": "Сканер преступников",
-      "pl": "Kill Warrant Scanner",
-      "cs": "Kill Warrant Scanner"
-    },
-    "Rail Gun": {
-      "es": "Cañón de Riel",
-      "pt": "Canhão Elétrico",
-      "de": "Schienenkanone",
-      "fr": "Canon électrique",
-      "ru": "Электромагнитная пушка",
-      "pl": "Rail Gun",
-      "cs": "Rail Gun"
-    },
-    "Power Distributor": {
-      "es": "Distribuidor de Energía",
-      "pt": "Distribuidor de Energia",
-      "de": "Energieverteiler",
-      "fr": "Répartiteur de Puissance",
-      "ru": "Распределитель питания",
-      "pl": "Power Distributor",
-      "cs": "Power Distributor"
-    },
-    "Fragment Cannon": {
-      "es": "Cañón de Fragmentación",
-      "pt": "Canhão de Fragmentos",
-      "de": "Splitterkanone",
-      "fr": "Canon à fragmentation",
-      "ru": "Залповое орудие",
-      "pl": "Fragment Cannon",
-      "cs": "Fragment Cannon"
-    },
-    "Mine Launcher": {
-      "es": "Lanzaminas",
-      "pt": "Lança Minas",
-      "de": "Minenwerfer",
-      "fr": "Lanceur de mines",
-      "ru": "Минирующее устройство",
-      "pl": "Mine Launcher",
-      "cs": "Mine Launcher"
-    },
-    "Beam Laser": {
-      "es": "Láser de Rayo",
-      "pt": "Laser Contínuo",
-      "de": "Strahlenlaser",
-      "fr": "Rayon Laser",
-      "ru": "Пучковый лазер",
-      "pl": "Beam Laser",
-      "cs": "Beam Laser"
-    },
-    "Armour": {
-      "es": "Blindaje",
-      "pt": "Blindagem",
-      "de": "Panzerung",
-      "fr": "Armure",
-      "ru": "Броня",
-      "pl": "Armour",
-      "cs": "Armour"
-    },
-    "Prospector Limpet Controller": {
-      "es": "Lanzador Dron Prospector",
-      "pt": "Controlador de Drone Prospector",
-      "de": "Drohnensteuerung Erzsucher",
-      "fr": "Controleur de drônes de prospection",
-      "ru": "Контроллер дронов геологов",
-      "pl": "Prospector Limpet Controller",
-      "cs": "Prospector Limpet Controller"
-    },
-    "Manifest Scanner": {
-      "es": "Escáner de Carga",
-      "pt": "Scanner de Manifesto",
-      "de": "Verzeichnisscanner",
-      "fr": "Scanner de soute",
-      "ru": "Сканер накладной",
-      "pl": "Manifest Scanner",
-      "cs": "Manifest Scanner"
-    },
-    "Burst Laser": {
-      "es": "Láser de Ráfagas",
-      "pt": "Laser de Rajada",
-      "de": "Salvenlaser",
-      "fr": "Laser à Rafale",
-      "ru": "Пульсирующий лазер",
-      "pl": "Burst Laser",
-      "cs": "Burst Laser"
-    },
-    "Heat Sink Launcher": {
-      "es": "Eyector Térmico",
-      "pt": "Lançador de Dissipador Térmico",
-      "de": "Kühlkörperwerfer",
-      "fr": "Dissipateur thermique",
-      "ru": "Теплоотводная катапульта",
-      "pl": "Heat Sink Launcher",
-      "cs": "Heat Sink Launcher"
-    },
-    "Pulse Laser": {
-      "es": "Láser de Pulso",
-      "pt": "Laser de Pulso",
-      "de": "Impulslaser",
-      "fr": "Laser à Impulsion",
-      "ru": "Импульсный лазер",
-      "pl": "Pulse Laser",
-      "cs": "Pulse Laser"
-    },
-    "Refinery": {
-      "es": "Refinería",
-      "pt": "Refinaria",
-      "de": "Raffinerie",
-      "fr": "Raffinerie",
-      "ru": "Очиститель",
-      "pl": "Refinery",
-      "cs": "Refinery"
-    },
-    "Auto Field-Maintenance Unit": {
-      "es": "Unidad de Automantenimiento",
-      "pt": "Unidade de Manutenção",
-      "de": "Automatische Feldwartungs-Einheit",
-      "fr": "MTA",
-      "ru": "Блок автоматического полевого ремонта",
-      "pl": "Auto Field-Maintenance Unit",
-      "cs": "Auto Field-Maintenance Unit"
-    },
-    "Fuel Transfer Limpet Controller": {
-      "es": "Lanzador Dron Combustible",
-      "pt": "Controlador de Drone Transferidor de Combustível",
-      "de": "Treibstofftransfer-Drohnensteuerung",
-      "fr": "Contrôleur de drone de ravitaillement",
-      "ru": "Контроллер дронов заправщиков",
-      "pl": "Fuel Transfer Limpet Controller",
-      "cs": "Fuel Transfer Limpet Controller"
-    },
-    "Frame Shift Drive": {
-      "es": "Motor de Distorsión",
-      "pt": "Motor de Distorção de Fase",
-      "de": "Frameshiftantrieb",
-      "fr": "FSD",
-      "ru": "FSD",
-      "pl": "Frame Shift Drive",
-      "cs": "Frame Shift Drive"
-    },
-    "Hatch Breaker Limpet Controller": {
-      "es": "Lanzador Dron Extractor",
-      "pt": "Controlador de Drone Quebra-Escotilha",
-      "de": "Steuereinheit Ladelukenöffner-Drohne",
-      "fr": "Perce-Soute",
-      "ru": "Контроллер дронов взломщиков",
-      "pl": "Hatch Breaker Limpet Controller",
-      "cs": "Hatch Breaker Limpet Controller"
-    },
-    "Fuel Scoop": {
-      "es": "Colector de Combustible",
-      "pt": "Coletor de Combustível",
-      "de": "Treibstoffsammler",
-      "fr": "Récupérateur de carburant",
-      "ru": "Топливозаборник",
-      "pl": "Fuel Scoop",
-      "cs": "Fuel Scoop"
-    },
-    "Torpedo Pylon": {
-      "es": "Lanzatorpedos",
-      "pt": "Pilone de Torpedo",
-      "de": "Torpedopylon",
-      "fr": "Torpilles",
-      "ru": "Торпедная стойка",
-      "pl": "Torpedo Pylon",
-      "cs": "Torpedo Pylon"
-    },
-    "Collector Limpet Controller": {
-      "es": "Lanzador Dron Colector",
-      "pt": "Controlador de Drone Coletor",
-      "de": "Steuerung Sammeldrohne",
-      "fr": "Controleur de drône collecteur",
-      "ru": "Контроллер дронов сборщиков",
-      "pl": "Collector Limpet Controller",
-      "cs": "Collector Limpet Controller"
-    },
-    "Shield Cell Bank": {
-      "es": "Células de Escudo",
-      "pt": "Banco de Célula de Escudo",
-      "de": "Schildzellenbank",
-      "fr": "Cellules d'énergie",
-      "ru": "Щитонакопитель",
-      "pl": "Shield Cell Bank",
-      "cs": "Shield Cell Bank"
-    },
-    "Aberrant Shield Pattern Analysis": {
-      "es": "Análisis de Patrón de Escudo Aberrantes",
-      "pt": "Análise de padrão de escudos Aberrante",
-      "de": "Abweichende Schildeinsatz-Analysen",
-      "fr": "Analyse de modèle de bouclier aberrante",
-      "ru": "Анализ аномального поведения щита",
-      "pl": "Aberrant Shield Pattern Analysis",
-      "cs": "Aberrant Shield Pattern Analysis"
-    },
-    "Abnormal Compact Emission Data": {
-      "es": "Compresión de Datos de Transmisiones Anormal",
-      "pt": "Dados de Emissão Compáctos Anormais",
-      "de": "Anormale Kompakte Emissionsdaten",
-      "fr": "Données d'émissions compactes anormales",
-      "ru": "Аномальные компактные данные об излучении",
-      "pl": "Abnormal Compact Emission Data",
-      "cs": "Abnormal Compact Emission Data"
-    },
-    "Adaptive Encryptors Capture": {
-      "es": "Captura de Encriptadores Adaptativos",
-      "pt": "Encriptadores Adaptativos Capturados",
-      "de": "Adaptive Verschlüsselungserfassung",
-      "fr": "Capture de cryptage évolutif",
-      "ru": "Захват адаптивного шифровальщика",
-      "pl": "Adaptive Encryptors Capture",
-      "cs": "Adaptive Encryptors Capture"
-    },
-    "Anomalous Bulk Scan Data": {
-      "es": "Datos de Escáner en Bruto Anómalos",
-      "pt": "Dados Brutos de Escâner Anômalos",
-      "de": "Anormale Massen-Scan-Daten",
-      "fr": "Fichier volumineux d'analyse anormal",
-      "ru": "Аномальный массив данных сканирования",
-      "pl": "Anomalous Bulk Scan Data",
-      "cs": "Anomalous Bulk Scan Data"
-    },
-    "Anomalous FSD Telemetry": {
-      "es": "Telemetría de MDD Anómala",
-      "pt": "Telemetria Anômala de MDD",
-      "de": "Anormale FSA-Telemetrie",
-      "fr": "Télémétrie FSD anormale",
-      "ru": "Аномальная телеметрия FSD",
-      "pl": "Anomalous FSD Telemetry",
-      "cs": "Anomalous FSD Telemetry"
-    },
-    "Antimony": {
-      "es": "Antimonio",
-      "pt": "Antimônio",
-      "de": "Antimon",
-      "fr": "Antimoine",
-      "ru": "Сурьма",
-      "pl": "Antimony",
-      "cs": "Antimony"
-    },
-    "Arsenic": {
-      "es": "Arsénico",
-      "pt": "Arsênico",
-      "de": "Arsen",
-      "fr": "Arsenic",
-      "ru": "Мышьяк",
-      "pl": "Arsenic",
-      "cs": "Arsenic"
-    },
-    "Articulation Motors": {
-      "es": "Motores de Articulación",
-      "pt": "Motores de articulações",
-      "de": "Gelenkmotoren",
-      "fr": "Moteur à articulation",
-      "ru": "Шарнирные моторы",
-      "pl": "Articulation Motors",
-      "cs": "Articulation Motors"
-    },
-    "Atypical Disrupted Wake Echoes": {
-      "es": "Ecos de Estelas Interrumpidas Atípicos",
-      "pt": "Interferência Atípica no Eco de Rastros",
-      "de": "Atypische FSA-Stör-Aufzeichnungen",
-      "fr": "Echos de sillages perturbés atypiques",
-      "ru": "Атипичное эхо поврежденного следа",
-      "pl": "Atypical Disrupted Wake Echoes",
-      "cs": "Atypical Disrupted Wake Echoes"
-    },
-    "Atypical Encryption Archives": {
-      "es": "Archivos Encriptados Atípicos",
-      "pt": "Arquivos De Encriptação Atípicos",
-      "de": "Atypische Verschlüsselungsarchive",
-      "fr": "Archives cryptées atypiques",
-      "ru": "Нетипичные архивы шифрования",
-      "pl": "Atypical Encryption Archives",
-      "cs": "Atypical Encryption Archives"
-    },
-    "Basic Conductors": {
-      "es": "Conductores Básicos",
-      "pt": "Condutores básicos",
-      "de": "Einfache Leiter",
-      "fr": "conducteurs simples",
-      "ru": "Простые проводники",
-      "pl": "Basic Conductors",
-      "cs": "Basic Conductors"
-    },
-    "Biotech Conductors": {
-      "es": "Conductores Biotecnológicos",
-      "pt": "Condutores biotecnológicos",
-      "de": "Biotech-Leiter",
-      "fr": "Conducteurs biotechniques",
-      "ru": "Биотехнические проводники",
-      "pl": "Biotech Conductors",
-      "cs": "Biotech Conductors"
-    },
-    "Bromellite": {
-      "es": "Bromelita",
-      "pt": "Bromelito",
-      "de": "Bromellit",
-      "fr": "Bromellite",
-      "ru": "Бромеллит",
-      "pl": "Bromellite",
-      "cs": "Bromellite"
-    },
-    "Cadmium": {
-      "es": "Cadmio",
-      "pt": "Cádmio",
-      "de": "Kadmium",
-      "fr": "Cadmium",
-      "ru": "Кадмий",
-      "pl": "Cadmium",
-      "cs": "Cadmium"
-    },
-    "Carbon": {
-      "es": "Carbono",
-      "pt": "Carbono",
-      "de": "Kohlenstoff",
-      "fr": "Carbone",
-      "ru": "Углерод",
-      "pl": "Carbon",
-      "cs": "Carbon"
-    },
-    "Chemical Distillery": {
-      "es": "Destilería Química",
-      "pt": "Destilaria química",
-      "de": "Chemiedestillerie",
-      "fr": "Distilerie chimique",
-      "ru": "Оборудование для перегонки химикатов",
-      "pl": "Chemical Distillery",
-      "cs": "Chemical Distillery"
-    },
-    "Chemical Manipulators": {
-      "es": "Manipuladores Químicos",
-      "pt": "Manipuladores químicos",
-      "de": "Chemische Manipulatoren",
-      "fr": "Manipulateurs chimiques",
-      "ru": "Манипуляторы для работы с химикатами",
-      "pl": "Chemical Manipulators",
-      "cs": "Chemical Manipulators"
-    },
-    "Chemical Processors": {
-      "es": "Procesadores Químicos",
-      "pt": "Processadores químicos",
-      "de": "Chemische Prozessoren",
-      "fr": "Processeurs chimiques",
-      "ru": "Оборудование для химобработки",
-      "pl": "Chemical Processors",
-      "cs": "Chemical Processors"
-    },
-    "Chemical Storage Units": {
-      "es": "Unidades de Almacenamiento Químico",
-      "pt": "Unidades de armazenamento químico",
-      "de": "Chemische Lagereinheiten",
-      "fr": "Unités de stockage chimique",
-      "ru": "Контейнеры для химикатов",
-      "pl": "Chemical Storage Units",
-      "cs": "Chemical Storage Units"
-    },
-    "Chromium": {
-      "es": "Cromo",
-      "pt": "Cromo",
-      "de": "Chrom",
-      "fr": "Chrome",
-      "ru": "Хром",
-      "pl": "Chromium",
-      "cs": "Chromium"
-    },
-    "Classified Scan Databanks": {
-      "es": "Datos de Escáner Clasificados",
-      "pt": "Banco de Dados de Escaneamento Confidenciais",
-      "de": "Scan-Datenbanken unter Verschluss",
-      "fr": "Banques de données d'analyse classifiées",
-      "ru": "Засекреченные базы данных сканирования",
-      "pl": "Classified Scan Databanks",
-      "cs": "Classified Scan Databanks"
-    },
-    "Classified Scan Fragment": {
-      "es": "Fragmento de Escáner Clasificado",
-      "pt": "Fragmento de Escaneamento Confidenciais",
-      "de": "Geheimes Scan Fragment",
-      "fr": "Données d'analyse classifiées parcellaires",
-      "ru": "Засекреченные фрагменты данных сканирования",
-      "pl": "Classified Scan Fragment",
-      "cs": "Classified Scan Fragment"
-    },
-    "CMM Composite": {
-      "es": "Compuesto CMM",
-      "pt": "Compostos CMM",
-      "de": "CMM-Komposit",
-      "fr": "composite MMC",
-      "ru": "CMM-композит",
-      "pl": "CMM Composite",
-      "cs": "CMM Composite"
-    },
-    "Compact Composites": {
-      "es": "Compuestos Compactos",
-      "pt": "Compostos compactos",
-      "de": "Kompakt-Komposit",
-      "fr": "Composites compacts",
-      "ru": "Спрессованные композиты",
-      "pl": "Compact Composites",
-      "cs": "Compact Composites"
-    },
-    "Compound Shielding": {
-      "es": "Escudos Compuestos",
-      "pt": "Proteção Composta",
-      "de": "Verbundschilde",
-      "fr": "Protection Composite",
-      "ru": "Многоступенчатая защита",
-      "pl": "Compound Shielding",
-      "cs": "Compound Shielding"
-    },
-    "Conductive Ceramics": {
-      "es": "Cerámicas Conductivas",
-      "pt": "Condutoras Cerâmicas",
-      "de": "Elektrokeramiken",
-      "fr": "Conducteurs en céramique",
-      "ru": "Проводящая керамика",
-      "pl": "Conductive Ceramics",
-      "cs": "Conductive Ceramics"
-    },
-    "Conductive Components": {
-      "es": "Componentes Conductivos",
-      "pt": "Componentes Condutores",
-      "de": "Leitfähige Komponenten",
-      "fr": "Composants conducteurs",
-      "ru": "Проводящие компоненты",
-      "pl": "Conductive Components",
-      "cs": "Conductive Components"
-    },
-    "Conductive Polymers": {
-      "es": "Polímeros Conductivos",
-      "pt": "Polímeros Condutores",
-      "de": "Leitfähige Polymere",
-      "fr": "Conducteurs en polymères",
-      "ru": "Проводящие полимеры",
-      "pl": "Conductive Polymers",
-      "cs": "Conductive Polymers"
-    },
-    "Configurable Components": {
-      "es": "Componentes Configurables",
-      "pt": "Componentes Configuráveis",
-      "de": "Konfigurierbare Komponenten",
-      "fr": "Composant paramétrables",
-      "ru": "Настраиваемые компоненты",
-      "pl": "Configurable Components",
-      "cs": "Configurable Components"
-    },
-    "Core Dynamics Composites": {
-      "es": "Compuestos de Core Dynamics",
-      "pt": "Componentes da Core Dynamics",
-      "de": "Core Dynamics Kompositwerkstoffe",
-      "fr": "Composites Core Dynamics",
-      "ru": "Композиты Core Dynamics",
-      "pl": "Core Dynamics Composites",
-      "cs": "Core Dynamics Composites"
-    },
-    "Cracked Industrial Firmware": {
-      "es": "Firmware Industrial Pirateado",
-      "pt": "Firmware Industrial Quebrado",
-      "de": "Gecrackte Industrie-Firmware",
-      "fr": "Micrologiciel industriel piraté",
-      "ru": "Взломанные промышленные микропрограммы",
-      "pl": "Cracked Industrial Firmware",
-      "cs": "Cracked Industrial Firmware"
-    },
-    "Crystal Shards": {
-      "es": "Piedras de Cristal",
-      "pt": "Fragmentos de Cristais",
-      "de": "Kristallscherben",
-      "fr": "Eclat de cristal",
-      "ru": "Осколки кристаллов",
-      "pl": "Crystal Shards",
-      "cs": "Crystal Shards"
-    },
-    "Datamined Wake Exceptions": {
-      "es": "Excepciones en Análisis de Estelas",
-      "pt": "Exceções de Dados Processados de Rastros",
-      "de": "FSA-Daten-Cache-Ausnahmen",
-      "fr": "Exploration de données de sillage anormales",
-      "ru": "Исключения из глубинного анализа данных следа",
-      "pl": "Datamined Wake Exceptions",
-      "cs": "Datamined Wake Exceptions"
-    },
-    "Decoded Emission Data": {
-      "es": "Datos de Emisión Descodificados",
-      "pt": "Dados de Emissão Decodificados",
-      "de": "Entschlüsselte Emissionsdaten",
-      "fr": "Données d'émissions décodées",
-      "ru": "Расшифрованные данные об излучении",
-      "pl": "Decoded Emission Data",
-      "cs": "Decoded Emission Data"
-    },
-    "Distorted Shield Cycle Recordings": {
-      "es": "Registros de Ciclo de Escudo Distorsionados",
-      "pt": "Registros Distorcidos de Ciclos de Escudo",
-      "de": "Gestörte Schildzyklus-Aufzeichnungen",
-      "fr": "Enregistrements de cycles de bouclier déformés",
-      "ru": "Поврежденные цикличные записи щита",
-      "pl": "Distorted Shield Cycle Recordings",
-      "cs": "Distorted Shield Cycle Recordings"
-    },
-    "Divergent Scan Data": {
-      "es": "Datos de Escáner Divergentes",
-      "pt": "Dados Escaneados Divergentes",
-      "de": "Divergente Scandaten",
-      "fr": "Données d'analyse divergentes",
-      "ru": "Неформатные данные сканирования",
-      "pl": "Divergent Scan Data",
-      "cs": "Divergent Scan Data"
-    },
-    "Eccentric Hyperspace Trajectories": {
-      "es": "Trayectorias de Hiperespacio Excéntricas",
-      "pt": "Trajetórias Escêntricas de Hiperespaço",
-      "de": "Exzentrische Hyperraum-Routen",
-      "fr": "Trajectoires hyperespace exentriques",
-      "ru": "Аномальные траектории в гиперпространстве",
-      "pl": "Eccentric Hyperspace Trajectories",
-      "cs": "Eccentric Hyperspace Trajectories"
-    },
-    "Electrochemical Arrays": {
-      "es": "Matriz Electroquímica",
-      "pt": "Matrizes Eletroquímicas",
-      "de": "Elektrochemische Detektoren",
-      "fr": "Réseaux électrochimiques",
-      "ru": "Электрохимические массивы",
-      "pl": "Electrochemical Arrays",
-      "cs": "Electrochemical Arrays"
-    },
-    "Emergency Power Cells": {
-      "es": "Celulas de Energía de Emergencia",
-      "pt": "Baterias de emergência",
-      "de": "Notfall-Energiezellen",
-      "fr": "Cellules d'énergie d'urgence",
-      "ru": "Аварийные энергоячейки",
-      "pl": "Emergency Power Cells",
-      "cs": "Emergency Power Cells"
-    },
-    "Energy Grid Assembly": {
-      "es": "Red de Energía",
-      "pt": "Montagem de rede de energia",
-      "de": "Energienetz-Gruppe",
-      "fr": "Système de réseau d'alimentation",
-      "ru": "Электросеть в сборе",
-      "pl": "Energy Grid Assembly",
-      "cs": "Energy Grid Assembly"
-    },
-    "Exceptional Scrambled Emission Data": {
-      "es": "Datos de Transmisiones Codificadas Excepcionales",
-      "pt": "Exceções nos Dados de Emissão Embaralhados",
-      "de": "Außergewöhnliche verschlüsselte Emissionsdaten",
-      "fr": "Données d'émissions brouillées exceptionnelles",
-      "ru": "Исключительные зашифрованные данные об излучении",
-      "pl": "Exceptional Scrambled Emission Data",
-      "cs": "Exceptional Scrambled Emission Data"
-    },
-    "Exhaust Manifold": {
-      "es": "Colector de Escape",
-      "pt": "Tubo exaustor",
-      "de": "Krümmer",
-      "fr": "Collecteur d'échappement",
-      "ru": "Выпускной коллектор",
-      "pl": "Exhaust Manifold",
-      "cs": "Exhaust Manifold"
-    },
-    "Exquisite Focus Crystals": {
-      "es": "Cristales de Enfoque Exquisitos",
-      "pt": "Cristais de Focalização Finos",
-      "de": "Erlesene Laserkristalle",
-      "fr": "Cristaux de focalisation sans défaut",
-      "ru": "Отборные фокусировочные кристаллы",
-      "pl": "Exquisite Focus Crystals",
-      "cs": "Exquisite Focus Crystals"
-    },
-    "Filament Composites": {
-      "es": "Compuestos de Filamentos",
-      "pt": "Compostos De Filamentos",
-      "de": "Filament-Komposite",
-      "fr": "Composites filamentaires",
-      "ru": "Волокнистые композиты",
-      "pl": "Filament Composites",
-      "cs": "Filament Composites"
-    },
-    "Flawed Focus Crystals": {
-      "es": "Cristales de Enfoque Defectuosos",
-      "pt": "Cristais de Focalização Falhos",
-      "de": "Fehlerhafte Fokuskristalle",
-      "fr": "Cristaux de focalisation imparfaits",
-      "ru": "Поврежденные фокусировочные кристаллы",
-      "pl": "Flawed Focus Crystals",
-      "cs": "Flawed Focus Crystals"
-    },
-    "Focus Crystals": {
-      "es": "Cristales de Enfoque",
-      "pt": "Cristais de Focalização",
-      "de": "Laserkristalle",
-      "fr": "Cristaux de focalisation",
-      "ru": "Фокусировочные кристаллы",
-      "pl": "Focus Crystals",
-      "cs": "Focus Crystals"
-    },
-    "Galvanising Alloys": {
-      "es": "Aleaciones Galvanizadas",
-      "pt": "Ligas Galvanizadas",
-      "de": "Galvanisierende Legierungen",
-      "fr": "Alliage galvanique",
-      "ru": "Сплавы для гальванизации",
-      "pl": "Galvanising Alloys",
-      "cs": "Galvanising Alloys"
-    },
-    "Germanium": {
-      "es": "Germanio",
-      "pt": "Germânio",
-      "de": "Germanium",
-      "fr": "Germanium",
-      "ru": "Германий",
-      "pl": "Germanium",
-      "cs": "Germanium"
-    },
-    "Grid Resistors": {
-      "es": "Red Resistiva",
-      "pt": "Resistores de Grade",
-      "de": "Gitterwiderstände",
-      "fr": "Résistance à grille",
-      "ru": "Наборные резисторы",
-      "pl": "Grid Resistors",
-      "cs": "Grid Resistors"
-    },
-    "Hardware Diagnostic Sensor": {
-      "es": "Sensor de Diagnóstico de Hardware",
-      "pt": "Sensor de diagnóstico de equipamentos",
-      "de": "Hardware-Diagnostiksensor",
-      "fr": "Capteur de diagnostic matériel",
-      "ru": "Сенсор диагностики оборудования",
-      "pl": "Hardware Diagnostic Sensor",
-      "cs": "Hardware Diagnostic Sensor"
-    },
-    "Heat Conduction Wiring": {
-      "es": "Cableado de Conducción Calorífica",
-      "pt": "Fiação De Condução Térmica",
-      "de": "Wärmeleitungsverdrahtung",
-      "fr": "Câblage de conduction thermique",
-      "ru": "Теплопроводящие провода",
-      "pl": "Heat Conduction Wiring",
-      "cs": "Heat Conduction Wiring"
-    },
-    "Heat Dispersion Plate": {
-      "es": "Placa de Dispersión de Calor",
-      "pt": "Placa de Dispersão Térmica",
-      "de": "Wärmeverteilungsplatte",
-      "fr": "Plaque de dissipation thermique",
-      "ru": "Теплорассеивающая пластина",
-      "pl": "Heat Dispersion Plate",
-      "cs": "Heat Dispersion Plate"
-    },
-    "Heat Exchangers": {
-      "es": "Intercambiadores de Calor",
-      "pt": "Trocadores Térmicos",
-      "de": "Wärmeaustauscher",
-      "fr": "Echangeurs de chaleur",
-      "ru": "Теплообменные агрегаты",
-      "pl": "Heat Exchangers",
-      "cs": "Heat Exchangers"
-    },
-    "Heat Resistant Ceramics": {
-      "es": "Cerámicas Resistentes al Calor",
-      "pt": "Cêramicas Termoresistentes",
-      "de": "Hitzefeste Keramik",
-      "fr": "Céramiques résistantes à la chaleur",
-      "ru": "Жаропрочная керамика",
-      "pl": "Heat Resistant Ceramics",
-      "cs": "Heat Resistant Ceramics"
-    },
-    "Heat Vanes": {
-      "es": "Palas Térmicas",
-      "pt": "Ventoinha Térmica",
-      "de": "Wärmeleitbleche",
-      "fr": "Vannes thermiques",
-      "ru": "Тепловые заслонки",
-      "pl": "Heat Vanes",
-      "cs": "Heat Vanes"
-    },
-    "Heatsink Interlink": {
-      "es": "Interconectores de Eyector Térmico",
-      "pt": "Dissipador térmico entrelaçado",
-      "de": "Kühlkörperverbinder",
-      "fr": "Interconnexion de dissipateur",
-      "ru": "Радиаторный соединитель",
-      "pl": "Heatsink Interlink",
-      "cs": "Heatsink Interlink"
-    },
-    "High Density Composites": {
-      "es": "Compuestos de Alta Densidad",
-      "pt": "Compostos de alta densidade",
-      "de": "Komposite hoher Dichte",
-      "fr": "Composites à haute densité",
-      "ru": "Высокоплотностные композиты",
-      "pl": "High Density Composites",
-      "cs": "High Density Composites"
-    },
-    "HN Shock Mount": {
-      "es": "Suspensión HN",
-      "pt": "Montagem de choque HN",
-      "de": "HN-Dämpferaufhängung",
-      "fr": "Protection antichoc HP",
-      "ru": "Разрядная установка HN",
-      "pl": "HN Shock Mount",
-      "cs": "HN Shock Mount"
-    },
-    "Hybrid Capacitors": {
-      "es": "Capacitadores Híbridos",
-      "pt": "Capacitores Híbridos",
-      "de": "Hybridkondensatoren",
-      "fr": "Condensateurs hybrides",
-      "ru": "Гибридные конденсаторы",
-      "pl": "Hybrid Capacitors",
-      "cs": "Hybrid Capacitors"
-    },
-    "Imperial Shielding": {
-      "es": "Escudos Imperiales",
-      "pt": "Proteção Imperial",
-      "de": "Imperiale Schilde",
-      "fr": "Protection impériale",
-      "ru": "Имперская защита",
-      "pl": "Imperial Shielding",
-      "cs": "Imperial Shielding"
-    },
-    "Improvised Components": {
-      "es": "Componentes Improvisados",
-      "pt": "Componentes Improvisados",
-      "de": "Behelfskomponenten",
-      "fr": "Composants improvisés",
-      "ru": "Кустарные компоненты",
-      "pl": "Improvised Components",
-      "cs": "Improvised Components"
-    },
-    "Inconsistent Shield Soak Analysis": {
-      "es": "Analisis de Absorcion de Esucudos Inconsistente",
-      "pt": "Análise Inconsistente de Escudo Atingidos",
-      "de": "Inkonsistente Schildleistungsanalyse",
-      "fr": "Analyse d'absorption de bouclier incohérente",
-      "ru": "Неполный анализ поглощения щита",
-      "pl": "Inconsistent Shield Soak Analysis",
-      "cs": "Inconsistent Shield Soak Analysis"
-    },
-    "Insulating Membrane": {
-      "es": "Membrana Aislante",
-      "pt": "Membrana de isolamento",
-      "de": "Isoliermembran",
-      "fr": "Membrane isolante",
-      "ru": "Изолирующая мембрана",
-      "pl": "Insulating Membrane",
-      "cs": "Insulating Membrane"
-    },
-    "Ion Distributor": {
-      "es": "Distribuidor de Iones",
-      "pt": "Distribuidor de íon",
-      "de": "Ionenverteiler",
-      "fr": "Distributeur d'ions",
-      "ru": "Ионный распределитель",
-      "pl": "Ion Distributor",
-      "cs": "Ion Distributor"
-    },
-    "Iron": {
-      "es": "Hierro",
-      "pt": "Ferro",
-      "de": "Eisen",
-      "fr": "Fer",
-      "ru": "Железо",
-      "pl": "Iron",
-      "cs": "Iron"
-    },
-    "Irregular Emission Data": {
-      "es": "Datos de Emisión Irregulares",
-      "pt": "Dados de Emissão Irregulares",
-      "de": "Irreguläre Emissionsdaten",
-      "fr": "Données d'émissions aberrantes",
-      "ru": "Нестандартные данные об излучении",
-      "pl": "Irregular Emission Data",
-      "cs": "Irregular Emission Data"
-    },
-    "Magnetic Emitter Coil": {
-      "es": "Bobina de Emisión Magnética",
-      "pt": "Bobina de emissão magnética",
-      "de": "Magnetische Emitterspule",
-      "fr": "Bobine d'émission magnétique",
-      "ru": "Спираль магнитного излучателя",
-      "pl": "Magnetic Emitter Coil",
-      "cs": "Magnetic Emitter Coil"
-    },
-    "Manganese": {
-      "es": "Manganeso",
-      "pt": "Manganês",
-      "de": "Mangan",
-      "fr": "Manganese",
-      "ru": "Марганец",
-      "pl": "Manganese",
-      "cs": "Manganese"
-    },
-    "Mechanical Components": {
-      "es": "Componentes Mecánicos",
-      "pt": "Componentes Mecânicos",
-      "de": "Mechanische Komponenten",
-      "fr": "Composants mécaniques",
-      "ru": "Механические компоненты",
-      "pl": "Mechanical Components",
-      "cs": "Mechanické komponenty"
-    },
-    "Mechanical Equipment": {
-      "es": "Equipamiento Mecánico",
-      "pt": "Equipamento Mecânico",
-      "de": "Mechanisches Equipment",
-      "fr": "Equipement mécanique",
-      "ru": "Механическое оборудование",
-      "pl": "Mechanical Equipment",
-      "cs": "Mechanical Equipment"
-    },
-    "Mechanical Scrap": {
-      "es": "Chatarra Mecánica",
-      "pt": "Sucata Mecânica",
-      "de": "Mechanischer Schrott",
-      "fr": "Ferraille mécanique",
-      "ru": "Механические отходы",
-      "pl": "Mechanical Scrap",
-      "cs": "Mechanical Scrap"
-    },
-    "Mercury": {
-      "es": "Mercurio",
-      "pt": "Mercúrio",
-      "de": "Quecksilber",
-      "fr": "Mercure",
-      "ru": "Ртуть",
-      "pl": "Mercury",
-      "cs": "Mercury"
-    },
-    "Micro Controllers": {
-      "es": "Microcontroladores",
-      "pt": "Microcontroladores",
-      "de": "Mikrocontroller",
-      "fr": "Microcontrôleurs",
-      "ru": "Микроконтроллеры",
-      "pl": "Micro Controllers",
-      "cs": "Micro Controllers"
-    },
-    "Micro-Weave Cooling Hoses": {
-      "es": "Mangueras de Refrigeración de Micro-tejidos",
-      "pt": "Mangueiras de resfriamento por micro-ondas",
-      "de": "Mikroflecht-Kühlschläuche",
-      "fr": "Tuyaux de refroidissement à microfilaments",
-      "ru": "Шланги системы охлаждения малых диаметров",
-      "pl": "Micro-Weave Cooling Hoses",
-      "cs": "Micro-Weave Cooling Hoses"
-    },
-    "Military Grade Alloys": {
-      "es": "Aleaciones de Grado Militar",
-      "pt": "Ligas nível militar",
-      "de": "Militärqualitätslegierungen",
-      "fr": "Alliages militaires",
-      "ru": "Сплавы военного назначения",
-      "pl": "Military Grade Alloys",
-      "cs": "Military Grade Alloys"
-    },
-    "Military Supercapacitors": {
-      "es": "Supercapacitadores Militares",
-      "pt": "Supercapacitores militares",
-      "de": "Militärische Superkondensatoren",
-      "fr": "Supercondensateurs militaires",
-      "ru": "Военные суперконденсаторы",
-      "pl": "Military Supercapacitors",
-      "cs": "Military Supercapacitors"
-    },
-    "Modified Consumer Firmware": {
-      "es": "Firmware de Consumo Modificado",
-      "pt": "Firmware de Consumo Modificado",
-      "de": "Modifizierte Consumer-Firmware",
-      "fr": "Micrologiciel consommateur modifié",
-      "ru": "Измененные пользовательские микропрограммы",
-      "pl": "Modified Consumer Firmware",
-      "cs": "Modified Consumer Firmware"
-    },
-    "Modified Embedded Firmware": {
-      "es": "Firmware Integrado Modificado",
-      "pt": "Firmware Embutido Modificado",
-      "de": "Modifizierte integrierte Firmware",
-      "fr": "Micrologiciel intégré modifié",
-      "ru": "Измененные встроенные микропрограммы",
-      "pl": "Modified Embedded Firmware",
-      "cs": "Modified Embedded Firmware"
-    },
-    "Modular Terminals": {
-      "es": "Terminales Modulares",
-      "pt": "Terminais modulares",
-      "de": "Modulterminals",
-      "fr": "Terminaux modulaires",
-      "ru": "Модульные терминалы",
-      "pl": "Modular Terminals",
-      "cs": "Modular Terminals"
-    },
-    "Molybdenum": {
-      "es": "Molibdeno",
-      "pt": "Molibdênio",
-      "de": "Molibdän",
-      "fr": "Molybdene",
-      "ru": "Молибден",
-      "pl": "Molybdenum",
-      "cs": "Molybdenum"
-    },
-    "Nanobreakers": {
-      "es": "Nanorrompedores",
-      "pt": "Nanodisjuntores",
-      "de": "Nanozertrümmerer",
-      "fr": "Nanodestructeurs",
-      "ru": "Нанопрерыватели",
-      "pl": "Nanobreakers",
-      "cs": "Nanobreakers"
-    },
-    "Neofabric Insulation": {
-      "es": "Neotejido Aislante",
-      "pt": "Neotecido de isolamento",
-      "de": "Neogewebe-Isolierung",
-      "fr": "Isolant en néotextile",
-      "ru": "Высокотехнологичная изоляция",
-      "pl": "Neofabric Insulation",
-      "cs": "Neofabric Insulation"
-    },
-    "Nickel": {
-      "es": "Níquel",
-      "pt": "Níquel",
-      "de": "Nickel",
-      "fr": "Nickel",
-      "ru": "Никель",
-      "pl": "Nickel",
-      "cs": "Nickel"
-    },
-    "Niobium": {
-      "es": "Niobio",
-      "pt": "Nióbio",
-      "de": "Niobium",
-      "fr": "Niobium",
-      "ru": "Ниобий",
-      "pl": "Niobium",
-      "cs": "Niobium"
-    },
-    "Open Symmetric Keys": {
-      "es": "Claves Simétricas Abiertas",
-      "pt": "Chaves Simétricas Abertas",
-      "de": "Offene symmetrische Schlüssel",
-      "fr": "clés symétriques ouvertes",
-      "ru": "Открытые симметричные ключи",
-      "pl": "Open Symmetric Keys",
-      "cs": "Open Symmetric Keys"
-    },
-    "Osmium": {
-      "es": "Osmio",
-      "pt": "Ósmio",
-      "de": "Osmium",
-      "fr": "Osmium",
-      "ru": "Осмий",
-      "pl": "Osmium",
-      "cs": "Osmium"
-    },
-    "Pattern Alpha Obelisk Data": {
-      "es": "Datos de Obelisco de Patrón Alpha",
-      "pt": "Dados de Obelisco de Padrão Alfa",
-      "de": "Alpha-Muster-Obeliskendaten",
-      "fr": "Données d'obélisque de type alpha",
-      "ru": "Данные с обелиска «Альфа»",
-      "pl": "Pattern Alpha Obelisk Data",
-      "cs": "Pattern Alpha Obelisk Data"
-    },
-    "Pattern Beta Obelisk Data": {
-      "es": "Datos de Obelisco de Patrón Beta",
-      "pt": "Dados de Obelisco de Padrão Beta",
-      "de": "Beta-Muster-Obeliskendaten",
-      "fr": "Données d'obélisque de type Beta",
-      "ru": "Данные с обелиска «Бета»",
-      "pl": "Pattern Beta Obelisk Data",
-      "cs": "Pattern Beta Obelisk Data"
-    },
-    "Pattern Delta Obelisk Data": {
-      "es": "Datos de Obelisco de Patrón Delta",
-      "pt": "Dados de Obelisco de Padrão Delta",
-      "de": "Delta-Muster-Obeliskendaten",
-      "fr": "Données d'obélisque de type Delta",
-      "ru": "Данные с обелиска «Дельта»",
-      "pl": "Pattern Delta Obelisk Data",
-      "cs": "Pattern Delta Obelisk Data"
-    },
-    "Pattern Epsilon Obelisk Data": {
-      "es": "Datos de Obelisco de Patrón Epsilon",
-      "pt": "Dados de Obelisco de Padrão Epsilon",
-      "de": "Epsilon-Muster-Obeliskendaten",
-      "fr": "Données d'obélisque de type Epsilon",
-      "ru": "Данные с обелиска «Эпсилон»",
-      "pl": "Pattern Epsilon Obelisk Data",
-      "cs": "Pattern Epsilon Obelisk Data"
-    },
-    "Pattern Gamma Obelisk Data": {
-      "es": "Datos de Obelisco de Patrón Gamma",
-      "pt": "Dados de Obelisco de Padrão Gama",
-      "de": "Gamma-Muster-Obeliskendaten",
-      "fr": "Données d'obélisque de type Gamma",
-      "ru": "Данные с обелиска «Гамма»",
-      "pl": "Pattern Gamma Obelisk Data",
-      "cs": "Pattern Gamma Obelisk Data"
-    },
-    "Peculiar Shield Frequency Data": {
-      "es": "Datos de Frecuencias de Escudo Peculiares",
-      "pt": "Dados da Frequência de Escudos Peculiares",
-      "de": "Verdächtige Schildfrequenz-Daten",
-      "fr": "Données de Fréquences de bouclier Singulières",
-      "ru": "Специфические данные о частоте щитов",
-      "pl": "Peculiar Shield Frequency Data",
-      "cs": "Peculiar Shield Frequency Data"
-    },
-    "Pharmaceutical Isolators": {
-      "es": "Aislantes Farmacéuticos",
-      "pt": "Isolantes farmacêuticos",
-      "de": "Pharmazeutische Isolatoren",
-      "fr": "Isolants pharmaceutiques",
-      "ru": "Фармацевтические изоляционные материалы",
-      "pl": "Pharmaceutical Isolators",
-      "cs": "Pharmaceutical Isolators"
-    },
-    "Phase Alloys": {
-      "es": "Aleaciones de Fase",
-      "pt": "Ligas de Fase",
-      "de": "Phasenlegierungen",
-      "fr": "Alliages de phase",
-      "ru": "Фазовые сплавы",
-      "pl": "Phase Alloys",
-      "cs": "Phase Alloys"
-    },
-    "Phosphorus": {
-      "es": "Fósforo",
-      "pt": "Fósforo",
-      "de": "Phosphor",
-      "fr": "Phosphore",
-      "ru": "Фосфор",
-      "pl": "Phosphorus",
-      "cs": "Phosphorus"
-    },
-    "Platinum": {
-      "es": "Platino",
-      "pt": "Platina",
-      "de": "Platin",
-      "fr": "platinium",
-      "ru": "Платина",
-      "pl": "Platinum",
-      "cs": "Platinum"
-    },
-    "Polonium": {
-      "es": "Polonio",
-      "pt": "Polônio",
-      "de": "Polonium",
-      "fr": "Polonium",
-      "ru": "Полоний",
-      "pl": "Polonium",
-      "cs": "Polonium"
-    },
-    "Polymer Capacitors": {
-      "es": "Capacitadores de Polímeros",
-      "pt": "Capacitores de Polímeros",
-      "de": "Polymerkondensatoren",
-      "fr": "Condensateurs en polymères",
-      "ru": "Полимерные конденсаторы",
-      "pl": "Polymer Capacitors",
-      "cs": "Polymer Capacitors"
-    },
-    "Power Converter": {
-      "es": "Convertidor de Energía",
-      "pt": "Conversor de energia",
-      "de": "Energiekonverter",
-      "fr": "Convertisseur de puissance",
-      "ru": "Преобразователь энергии",
-      "pl": "Power Converter",
-      "cs": "Power Converter"
-    },
-    "Power Transfer Bus": {
-      "es": "Conductos de Transferencia de Energía",
-      "pt": "Dutos de transferência de energia",
-      "de": "Energietransferbus",
-      "fr": "Conduit de transfert d’énergie",
-      "ru": "Энергообменная шина",
-      "pl": "Power Transfer Bus",
-      "cs": "Power Transfer Bus"
-    },
-    "Praseodymium": {
-      "es": "Praseodimio",
-      "pt": "Praseodímio",
-      "de": "Praseodym",
-      "fr": "Praseodyme",
-      "ru": "Празеодим",
-      "pl": "Praseodymium",
-      "cs": "Praseodymium"
-    },
-    "Precipitated Alloys": {
-      "es": "Aleaciones de Precipitación",
-      "pt": "Ligas Precipitadas",
-      "de": "Gehärtete Legierungen",
-      "fr": "Alliages précipités",
-      "ru": "Осажденные сплавы",
-      "pl": "Precipitated Alloys",
-      "cs": "Precipitated Alloys"
-    },
-    "Proprietary Composites": {
-      "es": "Compuestos con Patente",
-      "pt": "Compostos Propietários",
-      "de": "Kompositwerkstoffe",
-      "fr": "Composites brevetés",
-      "ru": "Патентованные композиты",
-      "pl": "Proprietary Composites",
-      "cs": "Proprietary Composites"
-    },
-    "Proto Heat Radiators": {
-      "es": "Protorradiadores Térmicos",
-      "pt": "Proto radiadores térmicos",
-      "de": "Proto-Wärmestrahler",
-      "fr": "Proto-radiateurs",
-      "ru": "Прототипы теплоизлучателей",
-      "pl": "Proto Heat Radiators",
-      "cs": "Proto Heat Radiators"
-    },
-    "Proto Light Alloys": {
-      "es": "Protoaleaciones Ligeras",
-      "pt": "Proto ligas leves",
-      "de": "Leichte Legierungen (Proto)",
-      "fr": "Proto-alliages légers",
-      "ru": "Опытные легкие сплавы",
-      "pl": "Proto Light Alloys",
-      "cs": "Proto Light Alloys"
-    },
-    "Proto Radiolic Alloys": {
-      "es": "Aleaciones Protorradiadas",
-      "pt": "Proto ligas radiólicas",
-      "de": "Radiologische Legierungen (Proto)",
-      "fr": "Proto-alliages radiologiques",
-      "ru": "Сплавы для изготовления зондов",
-      "pl": "Proto Radiolic Alloys",
-      "cs": "Proto Radiolic Alloys"
-    },
-    "Radiation Baffle": {
-      "es": "Deflector de Radiación",
-      "pt": "Defletor de radiação",
-      "de": "Strahlungsabweiser",
-      "fr": "Ecran antiradiation",
-      "ru": "Отражатель излучения",
-      "pl": "Radiation Baffle",
-      "cs": "Radiation Baffle"
-    },
-    "Refined Focus Crystals": {
-      "es": "Cristales de Enfoque Refinados",
-      "pt": "Cristais de focalização refinado",
-      "de": "Raffinierte Laserkristalle",
-      "fr": "Cristaux de focalisation raffinés",
-      "ru": "Обработанные фокусировочные кристаллы",
-      "pl": "Refined Focus Crystals",
-      "cs": "Refined Focus Crystals"
-    },
-    "Reinforced Mounting Plate": {
-      "es": "Placa de Anclaje Reforzada",
-      "pt": "Placa de montagem reforçada",
-      "de": "Verstärkte Trägerplatte",
-      "fr": "Plaque de montage renforcée",
-      "ru": "Усиленная монтажная плита",
-      "pl": "Reinforced Mounting Plate",
-      "cs": "Reinforced Mounting Plate"
-    },
-    "Ruthenium": {
-      "es": "Rutenio",
-      "pt": "Rutênio",
-      "de": "Ruthenium",
-      "fr": "Ruthenium",
-      "ru": "Рутений",
-      "pl": "Ruthenium",
-      "cs": "Ruthenium"
-    },
-    "Rhenium": {
-      "es": null,
-      "pt": "Rênio",
-      "de": "Rhenium",
-      "fr": null,
-      "ru": "Рений",
-      "pl": null,
-      "cs": "Rhenium"
-    },
-    "Salvaged Alloys": {
-      "es": "Aleaciones Recuperadas",
-      "pt": "Ligas recuperadas",
-      "de": "Geborgene Legierungen",
-      "fr": "Alliages récupérés",
-      "ru": "Захваченные сплавы",
-      "pl": "Salvaged Alloys",
-      "cs": "Salvaged Alloys"
-    },
-    "Samarium": {
-      "es": "Samario",
-      "pt": "Samário",
-      "de": "Samarium",
-      "fr": "Samarium",
-      "ru": "Самарий",
-      "pl": "Samarium",
-      "cs": "Samarium"
-    },
-    "Security Firmware Patch": {
-      "es": "Parche de Firmware de Seguridad",
-      "pt": "Atualização de firmware de segurança",
-      "de": "Sicherheits-Firmware-Patch",
-      "fr": "Mise à jour de micrologiciel de sécurité",
-      "ru": "Обновление для защитной микропрограммы",
-      "pl": "Security Firmware Patch",
-      "cs": "Security Firmware Patch"
-    },
-    "Selenium": {
-      "es": "Selenio",
-      "pt": "Selênio",
-      "de": "Selen",
-      "fr": "Selenium",
-      "ru": "Селен",
-      "pl": "Selenium",
-      "cs": "Selenium"
-    },
-    "Shield Emitters": {
-      "es": "Emisores de Escudo",
-      "pt": "Emissores de escudo",
-      "de": "Schildemitter",
-      "fr": "Emetteurs de bouclier",
-      "ru": "Щитоизлучатели",
-      "pl": "Shield Emitters",
-      "cs": "Shield Emitters"
-    },
-    "Shielding Sensors": {
-      "es": "Sensores de Escudo",
-      "pt": "Sensores para proteção",
-      "de": "Schildsensoren",
-      "fr": "Capteurs de bouclier",
-      "ru": "Сенсоры системы экранирования",
-      "pl": "Shielding Sensors",
-      "cs": "Shielding Sensors"
-    },
-    "Specialised Legacy Firmware": {
-      "es": "Firmware Heredado Especializado",
-      "pt": "Firmware especializado antigo",
-      "de": "Spezial-Legacy-Firmware",
-      "fr": "Micrologiciel spécialisé périmé",
-      "ru": "Специальные микропрограммы предыдущего поколения",
-      "pl": "Specialised Legacy Firmware",
-      "cs": "Specialised Legacy Firmware"
-    },
-    "Strange Wake Solutions": {
-      "es": "Extrañas Soluciones de Estelas",
-      "pt": "Soluções de rastro estranhas",
-      "de": "Seltsame FSA-Zielorte",
-      "fr": "Solutions de sillages anormales",
-      "ru": "Странные расчеты следа",
-      "pl": "Strange Wake Solutions",
-      "cs": "Strange Wake Solutions"
-    },
-    "Sulphur": {
-      "es": "Azufre",
-      "pt": "Enxofre",
-      "de": "Schwefel",
-      "fr": "Souffre",
-      "ru": "Сера",
-      "pl": "Sulphur",
-      "cs": "Sulphur"
-    },
-    "Tagged Encryption Codes": {
-      "es": "Códigos de Encriptación Marcados",
-      "pt": "Código de encriptação rotulados",
-      "de": "Getaggte Verschlüsselungscodes",
-      "fr": "Clés de cryptage balisées",
-      "ru": "Меченые шифровальные коды",
-      "pl": "Tagged Encryption Codes",
-      "cs": "Tagged Encryption Codes"
-    },
-    "Technetium": {
-      "es": "Tecnecio",
-      "pt": "Tecnécio",
-      "de": "Technetium",
-      "fr": "Technetium",
-      "ru": "Технеций",
-      "pl": "Technetium",
-      "cs": "Technetium"
-    },
-    "Telemetry Suite": {
-      "es": "Paquete de Telemetría",
-      "pt": "Conjunto de telemetria",
-      "de": "Telemetrie-Paket",
-      "fr": "Système de télémétrie",
-      "ru": "Телеметрический комплект",
-      "pl": "Telemetry Suite",
-      "cs": "Telemetry Suite"
-    },
-    "Tellurium": {
-      "es": "Teluro",
-      "pt": "Telúrio",
-      "de": "Tellur",
-      "fr": "Tellure",
-      "ru": "Теллурий",
-      "pl": "Tellurium",
-      "cs": "Tellurium"
-    },
-    "Tempered Alloys": {
-      "es": "Aleaciones Templadas",
-      "pt": "Ligas temperadas",
-      "de": "Vergütete Legierungen",
-      "fr": "Alliages trempés",
-      "ru": "Закаленные сплавы",
-      "pl": "Tempered Alloys",
-      "cs": "Tempered Alloys"
-    },
-    "Thermic Alloys": {
-      "es": "Aleaciones Térmicas",
-      "pt": "Ligas térmicas",
-      "de": "Thermische Legierungen",
-      "fr": "Alliages thermiques",
-      "ru": "Термические сплавы",
-      "pl": "Thermic Alloys",
-      "cs": "Thermic Alloys"
-    },
-    "Tin": {
-      "es": "Estaño",
-      "pt": "Estanho",
-      "de": "Zinn",
-      "fr": "Etain",
-      "ru": "Олово",
-      "pl": "Tin",
-      "cs": "Tin"
-    },
-    "Tungsten": {
-      "es": "Tungsteno",
-      "pt": "Tungstênio",
-      "de": "Wolfram",
-      "fr": "Tungstène",
-      "ru": "Вольфрам",
-      "pl": "Tungsten",
-      "cs": "Tungsten"
-    },
-    "Unexpected Emission Data": {
-      "es": "Datos de Emisión Inesperados",
-      "pt": "Dados de emissão inesperados",
-      "de": "Unerwartete Emissionsdaten",
-      "fr": "Données d'émissions inattendues",
-      "ru": "Неожиданные данные об излучении",
-      "pl": "Unexpected Emission Data",
-      "cs": "Unexpected Emission Data"
-    },
-    "Unidentified Scan Archives": {
-      "es": "Archivos de Escáner no Identificados",
-      "pt": "Arquivos de escaneamento não identificados",
-      "de": "Unidentifizierte Scan-Archive",
-      "fr": "Données d'analyse archivées non identifiées",
-      "ru": "Неопознанные архивы сканирования",
-      "pl": "Unidentified Scan Archives",
-      "cs": "Unidentified Scan Archives"
-    },
-    "Sensor Fragment": {
-      "es": "Fragmento Desconocido",
-      "pt": "Fragmento do sensor",
-      "de": "Unbekanntes Fragment",
-      "fr": "Fragment inconnu",
-      "ru": "Обломок сенсора",
-      "pl": "Sensor Fragment",
-      "cs": "Sensor Fragment"
-    },
-    "Untypical Shield Scans": {
-      "es": "Escáner de Escudos Atípico",
-      "pt": "Escaneamento de escudos atípicos",
-      "de": "Untypische Schildscans",
-      "fr": "Analyses de bouclier atypiques",
-      "ru": "Нетипичные данные сканирования щитов",
-      "pl": "Untypical Shield Scans",
-      "cs": "Untypical Shield Scans"
-    },
-    "Unusual Encrypted Files": {
-      "es": "Ficheros Encriptados Inusuales",
-      "pt": "Arquivos criptografados incomuns",
-      "de": "Ungewöhnliche verschlüsselte Files",
-      "fr": "Fichiers cryptés inhabituels",
-      "ru": "Особые зашифрованные файлы",
-      "pl": "Unusual Encrypted Files",
-      "cs": "Unusual Encrypted Files"
-    },
-    "Vanadium": {
-      "es": "Vanadio",
-      "pt": "Vanádio",
-      "de": "Vanadium",
-      "fr": "Vanadium",
-      "ru": "Ванадий",
-      "pl": "Vanadium",
-      "cs": "Vanadium"
-    },
-    "Worn Shield Emitters": {
-      "es": "Emisor de Escudos Desgastado",
-      "pt": "Emissores de Escudo Usado",
-      "de": "Gebrauchte Schildemitter",
-      "fr": "Émetteurs de bouclier usé",
-      "ru": "Изношенные щитоизлучатели",
-      "pl": "Worn Shield Emitters",
-      "cs": "Worn Shield Emitters"
-    },
-    "Yttrium": {
-      "es": "Ytrio",
-      "pt": "Ítrio",
-      "de": "Yttrium",
-      "fr": "Yttrium",
-      "ru": "Иттрий",
-      "pl": "Yttrium",
-      "cs": "Yttrium"
-    },
-    "Zinc": {
-      "es": "Zinc",
-      "pt": "Zinco",
-      "de": "Zink",
-      "fr": "Zinc",
-      "ru": "Цинк",
-      "pl": "Zinc",
-      "cs": "Zinc"
-    },
-    "Zirconium": {
-      "es": "Circonio",
-      "pt": "Zircônio",
-      "de": "Zirconium",
-      "fr": "Zirconium",
-      "ru": "Цирконий",
-      "pl": "Zirconium",
-      "cs": "Zirconium"
-    },
-    "ECM": {
-      "es": "Contramedida",
-      "pt": "CME",
-      "de": "EGM",
-      "fr": "CME",
-      "ru": "ЭПД",
-      "pl": "ECM",
-      "cs": "ECM"
-    },
-    "Hull": {
-      "es": "Casco",
-      "pt": "Casco",
-      "de": "Rumpfhülle",
-      "fr": "Coque",
-      "ru": "Корпус",
-      "pl": "Hull",
-      "cs": "Hull"
-    },
-    "FSD Interdictor": {
-      "es": "Interdictor",
-      "pt": "Interditor MDD",
-      "de": "FSA-Unterbrecher",
-      "fr": "Intercepteur FSD",
-      "ru": "Перехватчик FSD",
-      "pl": "FSD Interdictor",
-      "cs": "FSD Interdictor"
-    },
-    "Prospector LC": {
-      "es": "LD Prospector",
-      "pt": "Drone prospector",
-      "de": "DS Erzsucher",
-      "fr": "Contrôleur de drones Prospecteurs",
-      "ru": "Контроллер дронов геологов",
-      "pl": "Prospector LC",
-      "cs": "Prospector LC"
-    },
-    "Fuel Transfer LC": {
-      "es": "LD Repostaje",
-      "pt": "Drone de combustível",
-      "de": "DS Treibstofftransfer",
-      "fr": "Contrôleur de drones Ravitailleurs",
-      "ru": "Контроллер дронов заправщиков",
-      "pl": "Fuel Transfer LC",
-      "cs": "Fuel Transfer LC"
-    },
-    "Hatch Breaker LC": {
-      "es": "LD Extractor",
-      "pt": "Drone quebra-escotilha",
-      "de": "DS Ladelukenöffner",
-      "fr": "Contrôleur de drones Perce-Soute",
-      "ru": "Контроллер дронов взломщиков",
-      "pl": "Hatch Breaker LC",
-      "cs": "Hatch Breaker LC"
-    },
-    "Collector LC": {
-      "es": "LD Colector",
-      "pt": "Drone coletor",
-      "de": "DS Sammeldrohne",
-      "fr": "Contrôleur de drones Collecteurs",
-      "ru": "Контроллер дронов сборщиков",
-      "pl": "Collector LC",
-      "cs": "Collector LC"
-    },
-    "AFMU": {
-      "es": "Unidad de Automantenimiento",
-      "pt": "UMTS",
-      "de": "AFW",
-      "fr": "MTA",
-      "ru": "БАПР",
-      "pl": "AFMU",
-      "cs": "AFMU"
-    },
-    "Data": {
-      "es": "Datos",
-      "pt": "Dados",
-      "de": "Daten",
-      "fr": "Données",
-      "ru": "Данные",
-      "pl": "Dane",
-      "cs": "Data"
-    },
-    "Commodity": {
-      "es": "Mercancía",
-      "pt": "Mercadoria",
-      "de": "Handelsware",
-      "fr": "Marchandise",
-      "ru": "Товар",
-      "pl": "Towar",
-      "cs": "Komodita"
-    },
-    "Commodities": {
-      "es": "Mercancías",
-      "pt": "Marcadorias",
-      "de": "Handelswaren",
-      "fr": "Marchandises",
-      "ru": "Товары",
-      "pl": "Towary",
-      "cs": "Komodity"
-    },
-    "Material": {
-      "es": "Material",
-      "pt": "Material",
-      "de": "Material",
-      "fr": "Matériau",
-      "ru": "Материал",
-      "pl": "Materiały",
-      "cs": "Materiál"
-    },
-    "Materials": {
-      "es": "Materiales",
-      "pt": "Materiais",
-      "de": "Materialien",
-      "fr": "Matériaux",
-      "ru": "Материалы",
-      "pl": "Materiały",
-      "cs": "Materiály"
-    },
-    "Type": {
-      "es": "Tipo",
-      "pt": "Tipo",
-      "de": "Typ",
-      "fr": "Type",
-      "ru": "Тип",
-      "pl": "Typ",
-      "cs": "Typ"
-    },
-    "Name": {
-      "es": "Nombre",
-      "pt": "Nome",
-      "de": "Name",
-      "fr": "Nom",
-      "ru": "Название",
-      "pl": "Nazwa",
-      "cs": "Název"
-    },
-    "Progress": {
-      "es": "Progreso",
-      "pt": "Progresso",
-      "de": "Fortschritt",
-      "fr": "Progression",
-      "ru": "Прогресс",
-      "pl": "Postęp",
-      "cs": "Postup"
-    },
-    "Last update:": {
-      "es": "Ultima actualización",
-      "pt": "Última Atualização",
-      "de": "Letzte Aktualisierung:",
-      "fr": "Dernière Mise à jour",
-      "ru": "Последнее обновление:",
-      "pl": "Ostatnia aktualizacja:",
-      "cs": "Ostatní aktualizace:"
-    },
-    "Unlock Window": {
-      "es": "Desbloquear ventana",
-      "pt": "Desbloquear janela",
-      "de": "Fixierung aufheben",
-      "fr": "Débloquer la Fenêtre",
-      "ru": "Разблокировать окно",
-      "pl": "Odblokuj okno",
-      "cs": "Uvolni okno"
-    },
-    "Show entries with no stock?": {
-      "es": "¿Mostrar entradas sin stock?",
-      "pt": "Mostrar entradas sem estoque?",
-      "de": "Einträge ohne Bestand anzeigen?",
-      "fr": "Afficher les entrées sans stock?",
-      "ru": "Показывать пустые записи?",
-      "pl": "Pokaż składniki bez zapasów?",
-      "cs": "Zobrazit položky, které nemám ve skladu?"
-    },
-    "Show only for favorites?": {
-      "es": "¿Mostras sólo los favoritos?",
-      "pt": "Mostrar somente os favoritos?",
-      "de": "Nur Favoriten anzeigen?",
-      "fr": "Montrer uniquement les favoris?",
-      "ru": "Показывать только для избранных?",
-      "pl": "Pokaż składniki tylko dla ulubionych przepisów?",
-      "cs": "Zobrazit pouze oblíbené položky?"
-    },
-    "Grade Filter": {
-      "es": "Filtro de Grados",
-      "pt": "Filtro de grades",
-      "de": "Zugangsgrad Filter",
-      "fr": "Filtrer par Grades",
-      "ru": "Фильтр по уровню",
-      "pl": "Filtr poziomu",
-      "cs": "Filtrovat podle úrovně (Grade)"
-    },
-    "Engineer Filter": {
-      "es": "Filtro de Ingenieros",
-      "pt": "Filtro de engenheiros",
-      "de": "Ingenieur Filter",
-      "fr": "Filtrer par Ingénieurs",
-      "ru": "Фильтр по инженеру",
-      "pl": "Filtr inżyniera",
-      "cs": "Filtrovat podle inženýra"
-    },
-    "Type Filter": {
-      "es": "Filtro de Tipos",
-      "pt": "Filtro de tipos",
-      "de": "Typ Filter",
-      "fr": "Filtrer par Type",
-      "ru": "Фильтр по типу",
-      "pl": "Filtr typu",
-      "cs": "Filtrovat podle typu"
-    },
-    "Ignored And Favorite Filter": {
-      "es": "Filtro de Ignorados y Favoritos",
-      "pt": "Filtro de Ignorados e Favoritos",
-      "de": "Ignorierte und Favoriten Filter",
-      "fr": "Filtrer par Ignorés et Favoris",
-      "ru": "Фильтр по игнорируемым и избранным",
-      "pl": "Filtr ulubionych i ignorowanych",
-      "cs": "Filtrovat dle ignorovaných/oblíbených"
-    },
-    "Craftable Filter": {
-      "es": "Filtro de Elaborados",
-      "pt": "Filtro de produções",
-      "de": "Baubarkeit Filter",
-      "fr": "Filtrer par Craft disponible",
-      "ru": "Фильтр по доступности",
-      "pl": "Filtr możliwych do stworzenia",
-      "cs": "Filtr podle vyrobitelnosti"
-    },
-    "Ingredient Filter (Reversed)": {
-      "es": "Filtro de Ingredientes (Inverso)",
-      "pt": "Filtro de ingredientes (Inverter)",
-      "de": "Bestandteile Filter (invers)",
-      "fr": "Filtrer par Ingrédients (Inversé)",
-      "ru": "Фильтр по ингредиентам (Обратный)",
-      "pl": "Filtr składników (odwrócony)",
-      "cs": "Filtr ingrediencí (obrácený)"
-    },
-    "can craft": {
-      "es": "elaborable",
-      "pt": "Pode produzir",
-      "de": "baubar",
-      "fr": "dispos",
-      "ru": "можно создать",
-      "pl": "możesz stworzyć",
-      "cs": "Můžeš vyrobit"
-    },
-    "Reset": {
-      "es": "Reiniciar",
-      "pt": "Reiniciar",
-      "de": "Zurücksetzen",
-      "fr": "Reset",
-      "ru": "Сброс",
-      "pl": "Reset",
-      "cs": "Reset"
-    },
-    "Lock Window": {
-      "es": "Bloquear ventana",
-      "pt": "Bloquear janela",
-      "de": "Fenster fixieren",
-      "fr": "Bloquer la fenêtre",
-      "ru": "Заблокировать окно",
-      "pl": "Zablokuj okno",
-      "cs": "Zamkni okno"
-    },
-    "Show": {
-      "es": "Mostrar",
-      "pt": "Mostrar",
-      "de": "Anzeigen",
-      "fr": "Afficher",
-      "ru": "Открыть",
-      "pl": "Pokaż",
-      "cs": "Ukaž"
-    },
-    "Toggle Window Mode (Locked/Unlocked)": {
-      "es": "Cambiar el modo ventana (Bloqueado/Desbloqueado)",
-      "pt": "Alterar o modo janela (Bloqueado/Desbloquado)",
-      "de": "Fenster Modus umschalten (fixiert/freigegeben)",
-      "fr": "Mode de la fenêtre (Bloquer/arrière plan)",
-      "ru": "Переключить режим окна (Заблокировано/Разблокировано)",
-      "pl": "Przełącz tryb okna (zablokowany/odblokowany)",
-      "cs": "Prepni mód okna (zamčené/odemčené)"
-    },
-    "Reset Window Position": {
-      "es": "Restablecer la posición de la ventana",
-      "pt": "Reiniciar posição da janela",
-      "de": "Fensterposition zurücksetzen",
-      "fr": "Restaurer l'affichage de la fenêtre",
-      "ru": "Сбросить положение окна",
-      "pl": "Zresetuj położenie okna",
-      "cs": "Zresetuj pozici okna"
-    },
-    "Set Shortcut": {
-      "es": "Establecer acceso directo",
-      "pt": "Estabelecer acesso direto",
-      "de": "Tastenkombination setzen",
-      "fr": "Raccourcis",
-      "ru": "Настройка комбинации клавиш",
-      "pl": "Ustaw skrót",
-      "cs": "Nastav zkratku"
-    },
-    "Help": {
-      "es": "Ayuda",
-      "pt": "Ajuda",
-      "de": "Hilfe",
-      "fr": "Aide",
-      "ru": "Помощь",
-      "pl": "Pomoc",
-      "cs": "Pomoc"
-    },
-    "Quit": {
-      "es": "Salir",
-      "pt": "Sair",
-      "de": "Beenden",
-      "fr": "Quitter",
-      "ru": "Выйти",
-      "pl": "Wyjdź",
-      "cs": "Odejít"
-    },
-    "OK": {
-      "es": "OK",
-      "pt": "OK",
-      "de": "OK",
-      "fr": "OK",
-      "ru": "ОК",
-      "pl": "OK",
-      "cs": "OK"
-    },
-    "Cancel": {
-      "es": "Cancelar",
-      "pt": "Cancelar",
-      "de": "Abbrechen",
-      "fr": "Annuler",
-      "ru": "Отмена",
-      "pl": "Anuluj",
-      "cs": "Zrušit"
-    },
-    "Input a shortcut that's going to be used to show the window": {
-      "es": "Introduce el acceso directo que será utilizado para mostrar la ventana",
-      "pt": "Introduz um atalho que será utilizado para mostrar a janela",
-      "de": "Geben Sie eine Tastenkombination ein, die das Fenster anzeigt",
-      "fr": "Configurer une touche pour afficher la fenêtre",
-      "ru": "Нажмите комбинацию клавиш, которая будет раскрывать окно",
-      "pl": "Wprowadź skrót, który będzie wykorzystywany do przełączania okna",
-      "cs": "Zadejte zkratku, která se použije k zobrazení okna"
-    },
-    "You can't use an empty shortcut": {
-      "es": "No puedes usar un acceso directo vacío",
-      "pt": "Não é possível usar um atalho vazio",
-      "de": "Sie können keine leere Tastenkombination benutzen",
-      "fr": "Une touche doit être choisie",
-      "ru": "Вы не можете использовать пустую комбинацию клавиш",
-      "pl": "Nie możesz korzystać z pustego skrótu",
-      "cs": "Klávesová zkratka musí být vyplněna!"
-    },
-    "Error": {
-      "es": "Error",
-      "pt": "Erro",
-      "de": "Fehler",
-      "fr": "Erreur",
-      "ru": "Ошибка",
-      "pl": "Błąd",
-      "cs": "Chyba"
-    },
-    "The requested shortcut ({0}) is invalid": {
-      "es": "El acceso directo solicitado ({0}) no es válido",
-      "pt": "O atalho solicitado ({0}) é inválido",
-      "de": "Die gewünschte Tastenkombination ({0}) ist ungültig",
-      "fr": "La touche demandée ({0}) est invalide",
-      "ru": "Указанное сочетание клавиш ({0}) недействительно",
-      "pl": "Wybrany skrót ({0}) jest nieprawidłowy",
-      "cs": "Zvolená klávesová zkratka ({0}) je neplatná"
-    },
-    "You must use a regular key to accompany the modifier key like (Ctrl+F10 or Shift+R)": {
-      "es": "Debes utilizar una tecla normal para acompañar la tecla modificadora como (Ctrl+F10 or Shift+R)",
-      "pt": "Você deve usar uma tecla comum para acompanhar a tecla modificadora como (Ctrl+F10 ou Shift+R)",
-      "de": "Sie müssen eine reguläre Taste zusammen mit einer modifizierenden Taste verwenden wie (Strg+F10 or Shift+R)",
-      "fr": "Vous devez utiliser une touche normale pour accompagner la touche de modification comme (Ctrl + F10 ou Maj + R)",
-      "ru": "Вы должны использовать символьную клавишу вместе с клавишей-модификатором, например (Ctrl+F10 или Shift+R)",
-      "pl": "Musisz skorzystać z regularnego klawisza towarzyszącemu modyfikatorowi (np. Ctrl+F10 lub Shift+R)",
-      "cs": "Musíte použít standardní klávesu a pomocnou klávesu zároveň (např. Ctrl+F10 nebo Shift+R)"
-    },
-    "Something went wrong in parsing your logs, open an issue on GitHub with this information :": {
-      "es": "Se ha producido un error al analizar tus registros, envia una incidencia a GitHub con la siguiente información :",
-      "pt": "Algo deu errado na análise de seus logs, abra um problema no GitHub com esta informação",
-      "de": "Es ist ein Fehler beim Parsen Ihrer Logs aufgetreten, bitte öffnen Sie eine Issue-Meldung auf GitHub mit folgenden Angaben :",
-      "fr": "Erreur lors de la lecture de vos logs, merci d'ouvrir un ticket sur GitHub :",
-      "ru": "Что-то пошло не так при чтении ваших логов, создайте issue на GitHub c этой информацией :",
-      "pl": "Coś poszło nie tak podczas parsowania twoich logów, stwórz issue na GitHub-ie z tą informacją :",
-      "cs": "Nastal problém při parsování vašich logů, založte na GitHubu požadavek (New issue) s touto informací :"
-    },
-    "Unknown material, please contact the author ! {0}": {
-      "es": "Material desconocido, contacta con el autor  ! {0}",
-      "pt": "Material Thargoid, entre em contato com o autor! {0}",
-      "de": "Unbekanntes Material, bitte kontaktieren Sie den Autor ! {0}",
-      "fr": "Matériau inconnu, contactez l'auteur ! {0}",
-      "ru": "Неизвестный материал, пожалуйста свяжитесь с автором ! {0}",
-      "pl": "Nieznany materiał, skontaktuj się z autorem ! {0}",
-      "cs": "Neznámý materiál, kontaktujte autora aplikace ! {0}"
-    },
-    "Neither": {
-      "es": "Ninguno",
-      "pt": "Nenhum",
-      "de": "Weder noch",
-      "fr": "Autres",
-      "ru": "Никакой",
-      "pl": "Żadne",
-      "cs": "Žádný"
-    },
-    "Favorite": {
-      "es": "Favorito",
-      "pt": "Favorito",
-      "de": "Favoriten",
-      "fr": "Favoris",
-      "ru": "Избранные",
-      "pl": "Ulubione",
-      "cs": "Oblíbené"
-    },
-    "Ignored": {
-      "es": "Ignorado",
-      "pt": "Ignorado",
-      "de": "Ignorieren",
-      "fr": "Ignorés",
-      "ru": "Игнорируемые",
-      "pl": "Ignorowane",
-      "cs": "Ignorované"
-    },
-    "Craftable": {
-      "es": "Elaborable",
-      "pt": "Disponível para produção",
-      "de": "Baubare",
-      "fr": "Craftable",
-      "ru": "Доступны для изготовления",
-      "pl": "Możliwe do stworzenia",
-      "cs": "Vyrobitelné"
-    },
-    "Non Craftable": {
-      "es": "No Elaborable",
-      "pt": "Não disponível para produção",
-      "de": "Nicht baubare",
-      "fr": "Non Craftable",
-      "ru": "Недоступны для изготовления",
-      "pl": "Niemożliwe do stworzenia",
-      "cs": "Nevyrobitelné"
-    },
-    "Missing Commodities": {
-      "es": "Mercancía Perdida",
-      "pt": "Mercadoria Faltando",
-      "de": "Fehlende Handelswaren",
-      "fr": "Marchandise Manquantes",
-      "ru": "Не хватает товаров",
-      "pl": "Brakujące towary",
-      "cs": "Chybějící komodity"
-    },
-    "All": {
-      "es": "Todo",
-      "pt": "Tudo",
-      "de": "Alle",
-      "fr": "Tous",
-      "ru": "Все",
-      "pl": "Wszystko",
-      "cs": "Všechno"
-    },
-    "An error has been thrown by the application:": {
-      "es": "Se ha producido un error:",
-      "pt": "Ocorreu um erro:",
-      "de": "Ein Fehler ist aufgetreten:",
-      "fr": "Une erreur a été levée par l'application:",
-      "ru": "Приложением была выдана ошибка:",
-      "pl": "Błąd aplikacji:",
-      "cs": "Chyba aplikace:"
-    },
-    "Unrecoverable Error": {
-      "es": "Error Irrecuperable",
-      "pt": "Erro irrecuperável",
-      "de": "Fataler Fehler",
-      "fr": "Erreur Fatale",
-      "ru": "Неисправимая ошибка",
-      "pl": "Fatalny błąd",
-      "cs": "Fatální chyba"
-    },
-    "Close": {
-      "es": "Salir",
-      "pt": "Fechar",
-      "de": "Schließen",
-      "fr": "Fermer",
-      "ru": "Закрыть",
-      "pl": "Zamknij",
-      "cs": "Zavřít"
-    },
-    "Select a new log directory": {
-      "es": "Selecciona un nuevo directorio de logs",
-      "pt": "Selecione um novo diretório de log",
-      "de": "Wählen Sie ein neues Log Verzeichnis aus",
-      "fr": "Choisissez un nouveau répertoire de logs",
-      "ru": "Выбрать новую папку с log файлом",
-      "pl": "Wybierz nowy katalog z logami",
-      "cs": "Vyber nový adresář s logy hry"
-    },
-    "Couldn't find the log folder for elite, you'll have to specify it": {
-      "es": "No se pudo encontrar la carpeta de logs para Elite, tendrás que especificarla",
-      "pt": "Não foi possível encontrar a pasta de log para o elite, você precisará especificá-la",
-      "de": "Der Log Folder von Elite konnte nicht gefunden werden, bitte geben Sie ihn manuell an",
-      "fr": "Impossible de trouver le dossier des logs de Elite, vous devez le spécifier",
-      "ru": "Не удается найти папку с log файлом, вы должны выбрать ее самостоятельно",
-      "pl": "Nie znaleziono folderu z logami Elite, musisz go wybrać ręcznie",
-      "cs": "Nemůžu najít adresář s logy Elite, vyberte jej ručně:"
-    },
-    "Selected directory doesn't seem to contain any log file ; are you sure?": {
-      "es": "El directorio seleccionado no parece contener ningún log ; ¿Estás seguro?",
-      "pt": "O diretório selecionado parece não conter nenhum arquivo de log ; você tem certeza?",
-      "de": "Das gewählte Verzeichnis scheint keine Log Files zu enthalten ; Sind Sie sicher?",
-      "fr": "Le répertoire choisi ne semble pas contenir de fichier ; êtes vous sûr?",
-      "ru": "Выбранная папка не содержит log файл ; вы уверены?",
-      "pl": "Wygląda na to że wybrany katalog nie zawiera żadnego pliku z logami ; czy jesteś pewien?",
-      "cs": "Vybraný adresář zřejmě neobsahuje žádný log ; Jste si jistí?"
-    },
-    "Warning": {
-      "es": "Aviso",
-      "pt": "Atenção",
-      "de": "Warnung",
-      "fr": "Avertissement",
-      "ru": "Предупреждение",
-      "pl": "Ostrzeżenie",
-      "cs": "Varování"
-    },
-    "You did not select a log directory, EDEngineer won't be able to track changes. You can still use the app manually though.": {
-      "es": "No ha seleccionado un directorio de registro, EDEngineer no podrá realizar seguimiento de los cambios. Todavía puedes usar la aplicación manualmente.",
-      "pt": "Você não selecionou um diretório de registro, o EDEngineer não poderá acompanhar as alterações. Ainda assim, você ainda pode usar o aplicativo manualmente.",
-      "de": "Sie haben kein Log Verzeichnis gewählt, EDEngineer wird die Bestandsänderungen nicht aktualisieren können. Sie können die App jedoch manuell benutzen.",
-      "fr": "Vous n'avez pas choisi de dossier, EDEngineer ne sera pas capable de suivre vos changements. Il est cependant possible de continuer à utiliser l'application.",
-      "ru": "Вы не выбрали папку с log файлом, EDEngineer не сможет отслеживать изменения. Но вы все еще можете вносить изменения вручную.",
-      "pl": "Nie wybrałeś folderu z logami, EDEngineer nie będzie w stanie śledzić zmian. Nadal możesz korzystać z aplikacji manualnie.",
-      "cs": "Nezvolil jste adresář s logy hry, EDEngineer nebude schopen automaticky provádět změny. Stále však můžete používat aplikaci a ručně zadávat hodnoty."
-    },
-    "No folder in use ; click to change": {
-      "es": "Ninguna carpeta en uso ; haz clic para cambiar",
-      "pt": "Nenhuma pasta em uso ; clique para mudar",
-      "de": "Kein Verzeichnis in Verwendung ; Klicken Sie zum Ändern",
-      "fr": "Aucun répertoire ; cliquez ici pour changer",
-      "ru": "Папка не указана ; нажмите для изменения",
-      "pl": "Brak folderu w użyciu ; kliknij by zmienić",
-      "cs": "Nepoužívá se žádná složka ; klikni pro změnu"
-    },
-    "Favorite Blueprint Ready": {
-      "es": "Receta lista",
-      "pt": "Diagrama favorito pronto",
-      "de": "Bauplan fertig",
-      "fr": "Recette Prête",
-      "ru": "Чертеж готов",
-      "pl": "Ulubiony schemat gotowy",
-      "cs": "Oblíbený plánek připraven"
-    },
-    "Select Language": {
-      "es": "Cambiar idioma",
-      "pt": "Selecionar Idioma",
-      "de": "Sprache wählen",
-      "fr": "Choisissez la langue",
-      "ru": "Выбрать язык",
-      "pl": "Wybierz język",
-      "cs": "Vyber jazyk"
-    },
-    "Surface prospecting": {
-      "es": "Prospección de superficie",
-      "pt": "Prospecção de superfície",
-      "de": "Oberflächenabbau (SRV)",
-      "fr": "Prospection de surface",
-      "ru": "Поверхность планет",
-      "pl": "Górnictwo odkrywkowe (SRV)",
-      "cs": "Povrchový průzkum (SRV)"
-    },
-    "Mining": {
-      "es": "Minería",
-      "pt": "Mineração",
-      "de": "Abbau",
-      "fr": "Minage",
-      "ru": "Добыча",
-      "pl": "Górnictwo",
-      "cs": "Težba"
-    },
-    "Mission reward": {
-      "es": "Recompensa de misiones",
-      "pt": "Recompensa da missão",
-      "de": "Missions-Belohnungen",
-      "fr": "Récompense de mission",
-      "ru": "Награда за миссию",
-      "pl": "Nagroda za ukończenie misji",
-      "cs": "Odměna z mise"
-    },
-    "Mining (ice rings)": {
-      "es": "Minería (anillos helados)",
-      "pt": "Mineração (anéis de gelo)",
-      "de": "Abbau (Eis Ringe)",
-      "fr": "Minage (anneaux glacés)",
-      "ru": "Добыча (ледяные кольца)",
-      "pl": "Górnictwo (pierścienie: lodowe)",
-      "cs": "Těžba (ledové prstence)"
-    },
-    "Ship salvage (transport ships)": {
-      "es": "Rescate de naves (naves de transporte)",
-      "pt": "Destroços de naves (naves de transporte)",
-      "de": "Bergungsgut Schiffswrack (Transportschiffe)",
-      "fr": "Restes de vaisseaux détruits (Type: Transport)",
-      "ru": "Уничтожение корабля (транспортные)",
-      "pl": "Wrak statku (statki: transportowe)",
-      "cs": "Vrak lodě (transportní lodě)"
-    },
-    "Signal source (high security)": {
-      "es": "Señales (seguridad alta)",
-      "pt": "Fonte de sinal (segurança alta)",
-      "de": "Signalquelle (Hohe Sicherheit)",
-      "fr": "Source de Signal (Système : Haute Sécurité)",
-      "ru": "Источник сигнала (высокий уровень безопасности)",
-      "pl": "Źródła sygnału (wysokie bezpieczeństwo)",
-      "cs": "Zdroj signálu (vysoká bezpečnost - HIGH SEC.)"
-    },
-    "Surface POI": {
-      "es": "Puntos de interés de superficie",
-      "pt": "Pontos de interesse de superfície",
-      "de": "Planetenoberfläche POI",
-      "fr": "POI en Surface",
-      "ru": "Точки интереса на планетах",
-      "pl": "Planetarne POI",
-      "cs": "Planetární POI"
-    },
-    "Signal source": {
-      "es": "Señales",
-      "pt": "Fonte de sinal",
-      "de": "Signalquelle",
-      "fr": "Source de Signal",
-      "ru": "Источник сигнала",
-      "pl": "Źrodła sygnału",
-      "cs": "Zdroj signálu"
-    },
-    "Ship salvage (combat ships)": {
-      "es": "Rescate de naves (naves de combate)",
-      "pt": "Destroços de nave (naves de combate)",
-      "de": "Bergungsgut Schiffswrack (Kampfschiffe)",
-      "fr": "Restes de vaisseaux détruits (Type: Combat)",
-      "ru": "Уничтожение корабля (боевые)",
-      "pl": "Wrak statku (statki: bojowe)",
-      "cs": "Vrak lodě (bojové lodě)"
-    },
-    "Signal source (anarchy)": {
-      "es": "Señales (anarquía)",
-      "pt": "Fonte de sinal (anarquia)",
-      "de": "Signalquelle (Anarchie)",
-      "fr": "Source de signal (Système : Anarchique)",
-      "ru": "Источник сигнала (анархия)",
-      "pl": "Źródła sygnału (anarchia)",
-      "cs": "Zdroj signálu (anarchy)"
-    },
-    "Signal source (low security)": {
-      "es": "Señales (seguridad baja)",
-      "pt": "Fonte de sinal (baixa segurança)",
-      "de": "Signalquelle (Niedrige Sicherheit)",
-      "fr": "Source de signal (Système : Basse Sécuritée)",
-      "ru": "Источник сигнала (низкий уровень безопасности)",
-      "pl": "Źródła sygnału (niskie bezpieczeństwo)",
-      "cs": "Zdroj signálu (nízká bezpečnost - LOW SEC.)"
-    },
-    "Signal source (High grade emissions)": {
-      "es": "Señales (alta calidad)",
-      "pt": "Fonte de sinal (transmissões de alto grau)",
-      "de": "Signalquelle (Hochgradige Emissionen)",
-      "fr": "Source de signal (Emissions de haute qualitée)",
-      "ru": "Источник сигнала (высокоуровневое излучение)",
-      "pl": "Źródła sygnału (High grade emissions)",
-      "cs": "Zdroj signálu (High grade emissions)"
-    },
-    "Ship salvage (military & authority ships)": {
-      "es": "Rescate de naves (naves militares y de la autoridad)",
-      "pt": "Destroços de naves (naves militades e de autoridades)",
-      "de": "Bergungsgut Schiffswrack (Militär und Sicherheitsdienst)",
-      "fr": "Restes de vaisseaux détruits (Type: Militaire & Autorité Système)",
-      "ru": "Уничтожение корабля (военные и силы правопорядка)",
-      "pl": "Wrak statku (statki: wojskowe i policyjne)",
-      "cs": "Vrak lodi (vojenské a policejní lodě - mil.+auth.)"
-    },
-    "Destroyed Unknown Artefact": {
-      "es": "Destrucción de Artefacto Desconocido",
-      "pt": "Destruição de artefato desconhecido",
-      "de": "Zerstörtes unbekanntes Artefakt",
-      "fr": "Artéfact Inconnu Détruit / Fragment Inconnu",
-      "ru": "Уничтоженный Неизвестный Артефакт",
-      "pl": "Zniszczenie Nieznanego Artefaktu (UA)",
-      "cs": "Zničený neznámý artefakt (UA)"
-    },
-    "Ship scanning (combat ships)": {
-      "es": "Escaneo de naves (naves de combate)",
-      "pt": "Escaneamento de naves (naves de combate)",
-      "de": "Schiff Scan (Kampfschiffe)",
-      "fr": "Scan de vaisseaux de Combat",
-      "ru": "Сканирование корабля (боевые)",
-      "pl": "Skanowanie statków (typ: bojowe)",
-      "cs": "Skenování lodě (bojové lodě)"
-    },
-    "Deep space data beacon": {
-      "es": "Baliza de datos en espacio profundo",
-      "pt": "Sinalizador de dados em espaço profundo",
-      "de": "Privatdaten-Signal (deep space)",
-      "fr": "Balise de donnée (espace)",
-      "ru": "Данные маяка (дальний космос)",
-      "pl": "Skanowanie POI w przestrzeni kosmicznej",
-      "cs": "Skenování Beaconu (deep space)"
-    },
-    "Ship scanning (transport ships)": {
-      "es": "Escaneo de naves (naves de transporte)",
-      "pt": "Escaneamento de naves (naves de transporte)",
-      "de": "Schiff Scan (Transportschiffe)",
-      "fr": "Scan de vaisseaux (Type : Transport)",
-      "ru": "Сканирование корабля (транспортные)",
-      "pl": "Skanowanie statków (typ: transportowe)",
-      "cs": "Skenování lodě (transportní lodě)"
-    },
-    "High wake scanning": {
-      "es": "Escaneo de estelas de salto",
-      "pt": "Escaneamento de rastro alto",
-      "de": "Sogwolkenscan (Hohe Energie)",
-      "fr": "scan de sillages à haute energie",
-      "ru": "Сканирование высокочастотных следов FSD",
-      "pl": "Skanowanie High Wake",
-      "cs": "Skenování High Wake"
-    },
-    "Surface data point": {
-      "es": "Punto de datos de superficie",
-      "pt": "Ponto de dados de suferfície",
-      "de": "POI-Datenpunkt",
-      "fr": "POI",
-      "ru": "Наземные точки данных",
-      "pl": "Skanowanie planetarnego POI",
-      "cs": "Skenování POI na povrchu planety"
-    },
-    "Ship scanning": {
-      "es": "Escaneo de naves",
-      "pt": "Escaneamento de naves",
-      "de": "Schiff Scan",
-      "fr": "Scan de vaisseaux",
-      "ru": "Сканирование корабля",
-      "pl": "Skanowanie statków",
-      "cs": "Skenování lodě"
-    },
-    "Markets": {
-      "es": "Mercados",
-      "pt": "Mercados",
-      "de": "Märkte",
-      "fr": "Marchés",
-      "ru": "Рынки",
-      "pl": "Rynki",
-      "cs": "Obchody"
-    },
-    "Markets near Akhenaten (High Tech/Refinery)": {
-      "es": "Mercados cerca de Akhenaten (Alta Tecnología/Refinería)",
-      "pt": "Mercados perto de Akhenaten (Alta Tecnología/Refinaria)",
-      "de": "Märkte nahe Akhenaten (Hightech/Raffinerie)",
-      "fr": "Marchés près de Akhenaten (Haute Technologie/Raffinerie)",
-      "ru": "Рынки около Akhenaten (Высокотехнологичные/Перерабатывающие)",
-      "pl": "Rynki w pobliżu systemu Akhenaten (High Tech/Refinery)",
-      "cs": "Obchody v blízkosti Akhenaten (High Tech/Refinery)"
-    },
-    "Markets near Stafkarl (Industrial/Refinery)": {
-      "es": "Mercados cerca de Stafkarl (Industrial/Refinería)",
-      "pt": "Mercados perto de Stafkarl (Industrial/Refinaria)",
-      "de": "Märkte nahe Stafkarl (Industrie/Raffinerie)",
-      "fr": "Marchés près de Stafkarl (Industriel/Raffinerie)",
-      "ru": "Рынки около Stafkarl (Промышленные/Перерабатывающие)",
-      "pl": "Rynki w pobliżu systemu Stafkarl (Industrial/Refinery)",
-      "cs": "Obchody v blízkosti Stafkarl (Industrial/Refinery)"
-    },
-    "Markets near Run (Industrial/Refinery)": {
-      "es": "Mercados cerca de Run (Industrial/Refinería)",
-      "pt": "Mercados perto de Run (Industrial/Refinaria)",
-      "de": "Märkte nahe Run (Industrie/Raffinerie)",
-      "fr": "Marchés près de Run (Industriel/Raffinerie)",
-      "ru": "Рынки около Run (Промышленные/Перерабатывающие)",
-      "pl": "Rynki w pobliżu systemu Run (Industrial/Refinery)",
-      "cs": "Obchody v blízkosti Run (Industrial/Refinery)"
-    },
-    "Markets near Lei Jing (Industrial/Refinery)": {
-      "es": "Mercados cerca de Lei Jing (Industrial/Refinería)",
-      "pt": "Mercados perto de Lei Jing (Industrial/Refinaria)",
-      "de": "Märkte nahe Lei Jing (Industrie/Raffinerie)",
-      "fr": "Marchés près de Lei Jing (Industriel/Raffinerie)",
-      "ru": "Рынки около Lei Jing (Промышленные/Перерабатывающие)",
-      "pl": "Rynki w pobliżu systemu Lei Jing (Industrial/Refinery)",
-      "cs": "Obchody v blízkosti Lei Jing (Industrial/Refinery)"
-    },
-    "Markets near Myrbat (Industrial/Refinery)": {
-      "es": "Mercados cerca de Myrbat (Industrial/Refinería)",
-      "pt": "Mercados perto de Myrbat (Industrial/Refinaria)",
-      "de": "Märkte nahe Myrbat (Industrie/Raffinerie)",
-      "fr": "Marchés près de Myrbat (Industriel/Raffinerie)",
-      "ru": "Рынки около Myrbat (Промышленные/Перерабатывающие)",
-      "pl": "Rynki w pobliżu systemu Myrbat (Industrial/Refinery)",
-      "cs": "Obchody v blízkosti Myrbat (Industrial/Refinery)"
-    },
-    "Markets near 70 Tauri (Industrial/Extraction)": {
-      "es": "Mercados cerca de 70 Tauri (Industrial/Extracción)",
-      "pt": "Mercados perto de 70 Tauri (Industrial/Extração)",
-      "de": "Märkte nahe 70 Tauri (Industrie/Abbau)",
-      "fr": "Marchés près de 70 Tauri (Industriel/Extraction)",
-      "ru": "Рынки около 70 Tauri (Промышленные/Добывающие)",
-      "pl": "Rynki w pobliżu systemu 70 Tauri (Industrial/Extraction)",
-      "cs": "Obchody v blízkosti 70 Tauri (Industrial/Extraction)"
-    },
-    "Markets near Leesti (Industrial/Refinery)": {
-      "es": "Mercados cerca de Leesti (Industrial/Refinería)",
-      "pt": "Mercados perto de Leesti (Industrial/Refinaria)",
-      "de": "Märkte nahe Leesti (Industrie/Raffinerie)",
-      "fr": "Marchés près de Leesti (Industriel/Raffinerie)",
-      "ru": "Рынки около Leesti (Промышленные/Перерабатывающие)",
-      "pl": "Rynki w pobliżu systemu Leesti (Industrial/Refinery)",
-      "cs": "Obchody v blízkosti Leesti (Industrial/Refinery)"
-    },
-    "Markets near Lakota (Industrial/Extraction)": {
-      "es": "Mercados cerca de Lakota (Industrial/Extracción)",
-      "pt": "Mercados perto de Lakota (Industrial/Extração)",
-      "de": "Märkte nahe Lakota (Industrie/Abbau)",
-      "fr": "Marchés près de Lakota (Industriel/Extraction)",
-      "ru": "Рынки около Lakota (Промышленные/Добывающие)",
-      "pl": "Rynki w pobliżu systemu Lakota (Industrial/Extraction)",
-      "cs": "Obchody v blízkosti Lakota (Industrial/Extraction)"
-    },
-    "Markets near Cilbien Zu (Industrial/Extraction)": {
-      "es": "Mercados cerca de Cilbien Zu (Industrial/Extracción)",
-      "pt": "Mercados perto de Cilbien Zu (Industrial/Extração)",
-      "de": "Märkte nahe Cilbien Zu (Industrie/Abbau)",
-      "fr": "Marchés près de Cilbien Zu (Industriel/Extraction)",
-      "ru": "Рынки около Cilbien Zu (Промышленные/Добывающие)",
-      "pl": "Rynki w pobliżu systemu Cilbien Zu (Industrial/Extraction)",
-      "cs": "Obchody v blízkosti Cilbien Zu (Industrial/Extraction)"
-    },
-    "Markets near Heget (Industrial/Extraction)": {
-      "es": "Mercados cerca de Heget (Industrial/Extracción)",
-      "pt": "Mercados perto de Heget (Industrial/Extração)",
-      "de": "Märkte nahe Heget (Industrie/Abbau)",
-      "fr": "Marchés près de Heget (Industriel/Extraction)",
-      "ru": "Рынки около Heget (Промышленные/Добывающие)",
-      "pl": "Rynki w pobliżu systemu Heget (Industrial/Extraction)",
-      "cs": "Obchody v blízkosti Heget (Industrial/Extraction)"
-    },
-    "Markets near Eurybia (Extraction/Refinery)": {
-      "es": "Mercados cerca de Eurybia (Extracción/Refinería)",
-      "pt": "Mercados perto de Eurybia (Extracción/Refinaria)",
-      "de": "Märkte nahe Eurybia (Abbau/Raffinerie)",
-      "fr": "Marchés près de Eurybia (Extraction/Raffinerie)",
-      "ru": "Рынки около Eurybia (Добывающие/Перерабатывающие)",
-      "pl": "Rynki w pobliżu systemu Eurybia (Extraction/Refinery)",
-      "cs": "Obchody v blízkosti Eurybia (Extraction/Refinery)"
-    },
-    "Ingredient not used in any blueprint!": {
-      "es": "Elemento no usado en ninguna receta!",
-      "pt": "Ingrediente não utilizado em nenhum Diagrama",
-      "de": "Bestandteil in keinem bekannten Bauplan!",
-      "fr": "Materiau utilisé dans aucune recette!",
-      "ru": "Ингредиент не используется в чертежах!",
-      "pl": "Składnik nie jest używany w żadnym schemacie!",
-      "cs": "Ingredience není použita v žádném plánku!"
-    },
-    "+100% Fuel Efficiency": {
-      "es": "+100% Eficiencia de combustible",
-      "pt": "+100% Eficiência do combustível",
-      "de": "+100% Bonus Treibstoffeffizienz",
-      "fr": "+100% Efficacité du carburant",
-      "ru": "+100% к эффективности топлива",
-      "pl": "+100% efektywności paliwa",
-      "cs": "+100% efektivita paliva"
-    },
-    "+100% Hull Strength": {
-      "es": "+100% Resistencia de casco",
-      "pt": "+100% Força do casco",
-      "de": "+100% Bonus Rumpfstärke",
-      "fr": "+100% bonus coque",
-      "ru": "+100% к прочности корпуса",
-      "pl": "+100% wzmocnienie kadłuba",
-      "cs": "+100% k síle trupu"
-    },
-    "+100% Jump Range": {
-      "es": "+100% Distancia de salto",
-      "pt": "+100% Alcance do salto",
-      "de": "+100% Bonus Entfernung",
-      "fr": "+100% portée de saut",
-      "ru": "+100% к дальности прыжка",
-      "pl": "+100% zasięgu skoku",
-      "cs": "+100% k maximálnímu skoku"
-    },
-    "+100% Repair Speed": {
-      "es": "+100% Velocidad de reparación",
-      "pt": "+100% Velocidade de reparo",
-      "de": "+100% Bonus Reparaturgeschwindigkeit",
-      "fr": "+100% vitesse de réparation",
-      "ru": "+100% к скорости ремонта",
-      "pl": "+100% szybkości napraw",
-      "cs": "+100% k rychlosti opravování"
-    },
-    "+15% Damage Boost": {
-      "es": "+15% al daño",
-      "pt": "+15% Aumento de dano",
-      "de": "+15% Bonus Schaden",
-      "fr": "+15% dégâts",
-      "ru": "+15% к урону",
-      "pl": "+15% dodatkowych obrażeń",
-      "cs": "+15% k poškození touto zbraní"
-    },
-    "+200% Fuel Efficiency": {
-      "es": "+200% Eficiencia de combustible",
-      "pt": "+200% Eficiência do combustível",
-      "de": "+200% Bonus Treibstoffeffizienz",
-      "fr": "+200% Efficacité du carburant",
-      "ru": "+200% к эффективности топлива",
-      "pl": "+200% efektywności paliwa",
-      "cs": "+200% efektivita paliva"
-    },
-    "+25% Jump Range": {
-      "es": "+25% Distancia de salto",
-      "pt": "+25% Alcance do salto",
-      "de": "+25% Bonus Entfernung",
-      "fr": "+25% portée de saut",
-      "ru": "+25% к дальности прыжка",
-      "pl": "+25% zasięgu skoku",
-      "cs": "+25% k maximálnímu skoku"
-    },
-    "+30% Damage Boost": {
-      "es": "+30% al daño",
-      "pt": "+30% Aumento de dano",
-      "de": "+30% Bonus Schaden",
-      "fr": "+30% dégâts",
-      "ru": "+30% к урону",
-      "pl": "+30% dodatkowych obrażeń",
-      "cs": "+30% k poškození touto zbraní"
-    },
-    "+50% Hull Strength": {
-      "es": "+50% Resistencia de casco",
-      "pt": "+50% Força do casco",
-      "de": "+50% Bonus Rumpfstärke",
-      "fr": "+50% bonus coque",
-      "ru": "+50% к прочности корпуса",
-      "pl": "+50% wzmocnienie kadłuba",
-      "cs": "+50% k síle trupu"
-    },
-    "+50% Jump Range": {
-      "es": "+50% Distancia de salto",
-      "pt": "+50% Alcance do salto",
-      "de": "+50% Bonus Entfernung",
-      "fr": "+50% portée de saut",
-      "ru": "+50% к дальности прыжка",
-      "pl": "+50% zasięgu skoku",
-      "cs": "+50% k maximálnímu skoku"
-    },
-    "+50% Repair Speed": {
-      "es": "+50% Velocidad de reparación",
-      "pt": "+50% Velocidade de reparo",
-      "de": "+50% Bonus Reparaturgeschwindigkeit",
-      "fr": "+50% vitesse de réparation",
-      "ru": "+50% к скорости ремонта",
-      "pl": "+50% szybkości napraw",
-      "cs": "+50% k rychlosti opravování"
-    },
-    "AFM Refill": {
-      "es": "Recarga de UAM",
-      "pt": "Recarga de UMT",
-      "de": "AFW-Auffrischung",
-      "fr": "Unité de maintenance rechargée",
-      "ru": "Снабжение АПР",
-      "pl": "AFM Refill",
-      "cs": "AFM Refill"
-    },
-    "Explosive Munitions": {
-      "es": "Munición explosiva",
-      "pt": "Munição explosiva",
-      "de": "Explosivmunition",
-      "fr": "Munitions Explosives",
-      "ru": "Взрывчатые боеприпасы",
-      "pl": "Explosive Munitions",
-      "cs": "Explosive Munitions"
-    },
-    "FSD Injection": {
-      "es": "Inyección del MDD",
-      "pt": "Interditores de MDD",
-      "de": "FSA-Einspeisung",
-      "fr": "Injection FSD",
-      "ru": "Вброс в FSD",
-      "pl": "FSD Injection",
-      "cs": "FSD Injection"
-    },
-    "High Velocity Munitions": {
-      "es": "Munición de alta velocidad",
-      "pt": "Munições de alta velocidade",
-      "de": "Hochgeschwindigkeitsmunition",
-      "fr": "Munitions à Haute Vélocité",
-      "ru": "Высокоскоростные боеприпасы",
-      "pl": "High Velocity Munitions",
-      "cs": "High Velocity Munitions"
-    },
-    "Large Calibre Munitions": {
-      "es": "Munición de gran calibre",
-      "pt": "Munições de grande calibre",
-      "de": "Großkalibrige Munition",
-      "fr": "Munitions de gros Calibre",
-      "ru": "Крупнокалиберные боеприпасы",
-      "pl": "Large Calibre Munitions",
-      "cs": "Large Calibre Munitions"
-    },
-    "None": {
-      "es": "Ninguna",
-      "pt": "Nenhum",
-      "de": "Kein Bonus",
-      "fr": "aucun",
-      "ru": "Нет",
-      "pl": "Nic",
-      "cs": "Nic"
-    },
-    "Plasma Munitions": {
-      "es": "Munición de plasma",
-      "pt": "Munição de Plasma",
-      "de": "Plasmamunition",
-      "fr": "Munitions plasma",
-      "ru": "Плазменные боеприпасы",
-      "pl": "Plasma Munitions",
-      "cs": "Plasma Munitions"
-    },
-    "Small Calibre Munitions": {
-      "es": "Munición de pequeño calibre",
-      "pt": "Munição de Pequeno Calibre",
-      "de": "Kleinkalibrige Munition",
-      "fr": "Munitions de petit calibre",
-      "ru": "Мелкокалиберные боеприпасы",
-      "pl": "Small Calibre Munitions",
-      "cs": "Small Calibre Munitions"
-    },
-    "SRV Ammo Restock": {
-      "es": "Suministro de munición de VRS",
-      "pt": "Munição do VRS",
-      "de": "SRV-Munitionsnachladung",
-      "fr": "Munitions SRV",
-      "ru": "Боеприпасы для ТРП",
-      "pl": "Odnowienie amunicji SRV",
-      "cs": "Doplnění munice SRV"
-    },
-    "SRV Refuel": {
-      "es": "Repostaje del VRS",
-      "pt": "Reabastecimento de VRS",
-      "de": "SRV-Auftankung",
-      "fr": "Carburant SRV",
-      "ru": "Заправка ТРП",
-      "pl": "Tankowanie SRV",
-      "cs": "Doplnění paliva SRV"
-    },
-    "SRV Repair": {
-      "es": "Reparación del VRS",
-      "pt": "Reparo de VRS",
-      "de": "SRV-Reparaturen",
-      "fr": "Réparation SRV",
-      "ru": "Ремонт ТРП",
-      "pl": "Naprawa SRV",
-      "cs": "Oprava SRV"
-    },
-    "@Synthesis": {
-      "es": "@Síntesis",
-      "pt": "@Sínteses",
-      "de": "@Synthese",
-      "fr": "@Synthèse",
-      "ru": "@Синтез",
-      "pl": "@Synteza",
-      "cs": "@Syntéza"
-    },
-    "Launch Local API": {
-      "es": "Iniciar el servidor local de API",
-      "pt": "Inicie o servidor da API local",
-      "de": "Lokalen API Server starten",
-      "fr": "Lancer le serveur API local",
-      "ru": "Запустить локальный API сервер",
-      "pl": "Uruchom lokalne API",
-      "cs": "Start lokálního API serveru"
-    },
-    "Select the port for the local API server": {
-      "es": "Selecciona el puerto para el servidor local de API",
-      "pt": "Selecione a porta para o servidor da API local",
-      "de": "Wählen Sie den Port für den lokalen API Server",
-      "fr": "Sélectionnez le port pour le server API local",
-      "ru": "Выберите порт для локального API сервера",
-      "pl": "Wybierz port dla lokalnego serwera API",
-      "cs": "Vyber port lokálního API serveru"
-    },
-    "Auto run server on EDEngineer startup with this port? (if not ticked, the server will stop when you unlock/lock the window)": {
-      "es": "¿Deseas usar este puerto al ejecutar el servidor de EDEngineer? (si no está seleccionada esta opción el servidor podría detenerse cuando se bloquee o desbloquee la ventana)",
-      "pt": "Servidor de execução automática no EDEngineer, iniciar com esta porta? (se não estiver assinalado, o servidor pode parar quando a janela estiver bloqueada ou desbloqueada)",
-      "de": "Soll der Server beim Starten von EDEngineer automatisch mit diesem Port starten? (Wenn nicht selektiert, wird der Server beim freigeben/fixieren des Fensters stoppen)",
-      "fr": "Lancer automatiquement le serveur au démarrage avec ce port ? (sinon, le serveur s'arrêtera lorsque vous changerez le mode de la fenêtre (Bloquer/arrière plan)')",
-      "ru": "Запускать сервер с этим портом автоматически при запуске EDEngineer? (если этот параметр не выбран, сервер остановится, когда вы разблокируете/заблокируете окно)",
-      "pl": "Automatycznie uruchamiaj serwer podczas włączania EDEngineer na tym porcie? (jeżeli nie zaznaczone, serwer zostanie zatrzymany kiedy odblokujesz/zablokujesz okno)",
-      "cs": "Automaticky špouštět server s tímto portem při zapnutí EDEngineera? (pokud není zašrtnuto, server se zastaví při odemčení/zamčení okna)"
-    },
-    "Shopping List": {
-      "es": "Lista de la compra",
-      "pt": "Lista de compras",
-      "de": "Einkaufsliste",
-      "fr": "Liste de courses",
-      "ru": "Список покупок",
-      "pl": "Lista zakupów",
-      "cs": "Nákupní seznam"
-    },
-    "Needed for Marco Qwent (25)": {
-      "es": "Necesario para Marco Qwent (25)",
-      "pt": "Necessário para Marco Qwent (25)",
-      "de": "Benötigt für Marco Qwent (25)",
-      "fr": "Nécessaire pour Marco Qwent (25)",
-      "ru": "Необходимо для Marco Qwent (25)",
-      "pl": "Potrzebne dla Marco Qwent (25)",
-      "cs": "Potřebné pro Marco Qwenta (25)"
-    },
-    "Needed for Ram Tah (50)": {
-      "es": "Necesario para Ram Tah (50)",
-      "pt": "Necessário para Ram Tah (50)",
-      "de": "Benötigt für Ram Tah (50)",
-      "fr": "Nécessaire pour Ram Tah (50)",
-      "ru": "Необходимо для Ram Tah (50)",
-      "pl": "Potrzebne dla Ram Tah (50)",
-      "cs": "Potřebné pro Ram Taha (50)"
-    },
-    "Needed for Professor Palin (25)": {
-      "es": "Necesario para Professor Palin (25)",
-      "pt": "Necessário para o Professor Palin (25)",
-      "de": "Benötigt für Professor Palin (25)",
-      "fr": "Nécessaire pour Professor Palin (25)",
-      "ru": "Необходимо для Professor Palin (25)",
-      "pl": "Potrzebne dla Professor Palin (25)",
-      "cs": "Potřebné pro profesora Palina (25)"
-    },
-    "Needed for Tiana Fortune (50)": {
-      "es": "Necesario para Tiana Fortune (50)",
-      "pt": "Necessário para Tiana Fortune (50)",
-      "de": "Benötigt für Tiana Fortune (50)",
-      "fr": "Nécessaire pour Tiana Fortune (50)",
-      "ru": "Необходимо для Tiana Fortune (50)",
-      "pl": "Potrzebne dla Tiana Fortune (50)",
-      "cs": "Potřebné pro Tianu Fortune (50)"
-    },
-    "Needed for The Sarge (50)": {
-      "es": "Necesario para The Sarge (50)",
-      "pt": "Necessário para The Sarge (50)",
-      "de": "Benötigt für The Sarge (50)",
-      "fr": "Nécessaire pour The Sarge (50)",
-      "ru": "Необходимо для The Sarge (50)",
-      "pl": "Potrzebne dla The Sarge (50)",
-      "cs": "Potřebné pro The Sarge (50)"
-    },
-    "Needed for Bill Turner (50)": {
-      "es": "Necesario para Bill Turner (50)",
-      "pt": "Necessário para Bill Turner (50)",
-      "de": "Benötigt für Bill Turner (50)",
-      "fr": "Nécessaire pour Bill Turner (50)",
-      "ru": "Необходимо для Bill Turner (50)",
-      "pl": "Potrzebne dla Bill Turner (50)",
-      "cs": "Potřebné pro Billa Turnera (50)"
-    },
-    "Show information about resources?": {
-      "es": "Mostrar información sobre recursos?",
-      "pt": "Mostrar informação sobre recursos?",
-      "de": "Informationen über Ressourcen anzeigen?",
-      "fr": "Afficher les informations sur les ressources ?",
-      "ru": "Показывать информацию о ресурсах?",
-      "pl": "Pokaż dodatkowe informacje o komponentach",
-      "cs": "Zobrazit informace o tom, kde lze získat data/materiály?"
-    },
-    "Count": {
-      "es": "Número",
-      "pt": "Número",
-      "de": "Anzahl",
-      "fr": "Nombre",
-      "ru": "Количество",
-      "pl": "Ilość",
-      "cs": "Počet"
-    },
-    "Thargoid Ship Signature": {
-      "es": "Señal de nave desconocida",
-      "pt": "Assinatura de nave desconhecida",
-      "de": "Unbekannte Schiffsignatur",
-      "fr": "Signature de Vaisseau Thargoid",
-      "ru": "Сигнатура таргоидского корабля",
-      "pl": "Thargoid Ship Signature",
-      "cs": "Thargoid Ship Signature"
-    },
-    "Thargoid Wake Data": {
-      "es": "Datos de estela desconocida",
-      "pt": "Dados de Rastro Desconhecido",
-      "de": "Unbekannte Sogwolke",
-      "fr": "Donnée de Sillage Thargoid",
-      "ru": "Данные следа таргоидского корабля",
-      "pl": "Thargoid Wake Data",
-      "cs": "Thargoid Wake Data"
-    },
-    "Check all filters": {
-      "es": "Marcar todos los filtros",
-      "pt": "Marcar todos os filtros",
-      "de": "Alle Filter anwählen",
-      "fr": "Tous les filtres",
-      "ru": "Включить все фильтры",
-      "pl": "Zaznacz wszystkie filtry",
-      "cs": "Vyber všechny filtry"
-    },
-    "Uncheck all filters": {
-      "es": "Descarmar todos los filtros",
-      "pt": "Desmarcar todos os filtros",
-      "de": "Alle Filter abwählen",
-      "fr": "Aucun filtre",
-      "ru": "Отключить все фильтры",
-      "pl": "Odznacz wszystkie filtry",
-      "cs": "Zruš všechny filtry"
-    },
-    "Rarity": {
-      "es": "Rareza",
-      "pt": "Raridade",
-      "de": "Seltenheit",
-      "fr": "Rareté",
-      "ru": "Редкость",
-      "pl": "Rzadkość",
-      "cs": "Vzácnost"
-    },
-    "Kind": {
-      "es": "Tipo",
-      "pt": "Tipo",
-      "de": "Art",
-      "fr": "Type",
-      "ru": "Вид",
-      "pl": "Rodzaj",
-      "cs": "Druh"
-    },
-    "Search": {
-      "es": "Buscar",
-      "pt": "Buscar",
-      "de": "Suche",
-      "fr": "Recherche",
-      "ru": "Поиск",
-      "pl": "Szukaj",
-      "cs": "Hledat"
-    },
-    "Apply": {
-      "es": "Aplicar",
-      "pt": "Aplicar",
-      "de": "Anwenden",
-      "fr": "Appliquer",
-      "ru": "Применить",
-      "pl": "Zastosuj",
-      "cs": "Použít"
-    },
-    "Rare": {
-      "es": "Raro",
-      "pt": "Raro",
-      "de": "selten",
-      "fr": "Rare",
-      "ru": "Редкие",
-      "pl": "Rzadka",
-      "cs": "Rare (vzácný)"
-    },
-    "Very Rare": {
-      "es": "Muy Raro",
-      "pt": "Muito raro",
-      "de": "sehr selten",
-      "fr": "Très rare",
-      "ru": "Очень редкие",
-      "pl": "Bardzo rzadka",
-      "cs": "Very Rare (velmi vzácný)"
-    },
-    "Very Common": {
-      "es": "Muy Común",
-      "pt": "Muito comum",
-      "de": "sehr häufig",
-      "fr": "Très commun",
-      "ru": "Очень распространенные",
-      "pl": "Bardzo pospolita",
-      "cs": "Very Common (velmi běžný)"
-    },
-    "Common": {
-      "es": "Común",
-      "pt": "Comum",
-      "de": "häufig",
-      "fr": "Commun",
-      "ru": "Распространенные",
-      "pl": "Pospolita",
-      "cs": "Common (běžný)"
-    },
-    "Standard": {
-      "es": "estándar",
-      "pt": "Padrão",
-      "de": "Standard",
-      "fr": "Standard",
-      "ru": "Обычные",
-      "pl": "Standardowa",
-      "cs": "Standard"
-    },
-    "Multiple Blueprints Ready": {
-      "es": "Múltiples Planos Listos",
-      "pt": "Múltiplos Diagramas Prontos",
-      "de": "verschiedene Baupläne fertig",
-      "fr": "Multiple Plans de Fabrications Disponibles",
-      "ru": "Готово несколько чертежей",
-      "pl": "Wiele schematów gotowych do stworzenia",
-      "cs": "Několik plánků je připraveno"
-    },
-    "{0} blueprints are available to craft!": {
-      "es": "¡{0} planos están disponibles para crear!",
-      "pt": "{0} diagramas estão disponiveis para produção!",
-      "de": "{0} Baupläne stehen zur Herstellung zur Verfügung!",
-      "fr": "{0} plans de fabrications sont disponibles pour la production",
-      "ru": "Можно создать {0} чертежей!",
-      "pl": "Można stworzyć {0} schematów!",
-      "cs": "{0} plánků je připraveno k výrobě!"
-    },
-    "Sensors": {
-      "es": "Sensores",
-      "pt": "Sensores",
-      "de": "Sensoren",
-      "fr": "Capteurs",
-      "ru": "Сенсоры",
-      "pl": "Sensors",
-      "cs": "Sensors"
-    },
-    "Surface Scanner": {
-      "es": "Escáner de Superficie",
-      "pt": "Scanners de superfície",
-      "de": "Oberflächen-Scanner",
-      "fr": "Scanner de Surface",
-      "ru": "Сканер поверхности",
-      "pl": "Surface Scanner",
-      "cs": "Surface Scanner"
-    },
-    "Wake Scanner": {
-      "es": "Escáner de Estela",
-      "pt": "Scanner de rastro",
-      "de": "Sogwolkenscanner",
-      "fr": "Scanner de Sillage",
-      "ru": "Сканер следа",
-      "pl": "Wake Scanner",
-      "cs": "Wake Scanner"
-    },
-    "Last update: ": {
-      "es": "Última actualización: ",
-      "pt": "Última atualização",
-      "de": "letzte Aktualisierung",
-      "fr": "Dernière mise à jour: ",
-      "ru": "Последнее обновление: ",
-      "pl": "Ostatnia aktualizacja:",
-      "cs": "Poslední aktualizace:"
-    },
-    "Silent Launch": {
-      "es": "Iniciar Minimizado",
-      "pt": "Iniciar Minimizado",
-      "de": "Start minimiert",
-      "fr": "Démarrage Silencieux",
-      "ru": "Скрытый запуск",
-      "pl": "Ciche uruchomienie",
-      "cs": "Tichý start"
-    },
-    "Search visible blueprints (by Type, Name, Grade or Engineer) - split your terms with a space for multi-criteria search": {
-      "es": null,
-      "pt": "Procure diagramas disponíveis (por Tipo, Nome, Grau ou Engenheiro) - separe os termos com um espaço para pesquisa multi-critério",
-      "de": "Suche nach verfügbaren Bauplänen (Begriffe durch 'Leerzeichen' trennen)",
-      "fr": "Rechercher les plans de fabrications visible (par Type, Nom, Grade ou Ingénieur) - séparez vos termes avec un espace pour une recharche multi-critères",
-      "ru": "Поиск видимых чертежей (по Типу, Названию, Уровню или Инженеру) - введите условия через пробел для использования нескольких критериев сортировки",
-      "pl": "Przeszukaj widoczne schematy (po Typie, Nazwie, Poziomie lub nazwie Inżyniera) - oddziel terminy przy użyciu spacji by wyszukiwać za pomocą wielokrotnych kryterii",
-      "cs": "Hledat vyditelné plánky (podle typu, jména, grade nebo inženýra) - odděl hledané výrazy mezerou pro vyhledání všech výrazů najednou"
-    },
-    "Configure Notifications": {
-      "es": "Configurar Notificaciones",
-      "pt": "Configurar notificações",
-      "de": "Benachrichtigung Konfigurieren",
-      "fr": "Configurer les Notifications",
-      "ru": "Настройка оповещений",
-      "pl": "Skonfiguruj powiadomienia",
-      "cs": "Konfiguruj upozornění"
-    },
-    "Notifications": {
-      "es": "Notificaciones",
-      "pt": "Notificações",
-      "de": "Benachrichtigung",
-      "fr": "Notifications",
-      "ru": "Оповещения",
-      "pl": "Powiadomienia",
-      "cs": "Upozornění"
-    },
-    "Test Notification": {
-      "es": "Notificación de Prueba",
-      "pt": "Notificação de teste",
-      "de": "Test-Benachrichtigung",
-      "fr": "Tester la Notification",
-      "ru": "Проверка оповещения",
-      "pl": "Próbne powiadomienie",
-      "cs": "Testovat upozornění"
-    },
-    "Toast": {
-      "es": null,
-      "pt": "Notificação",
-      "de": "Toast",
-      "fr": "Notification",
-      "ru": "Toast",
-      "pl": "Pop-up",
-      "cs": "Pop-up"
-    },
-    "Voice": {
-      "es": "Voz",
-      "pt": "Voz",
-      "de": "Stimme",
-      "fr": "Voix",
-      "ru": "Голос",
-      "pl": "Głos",
-      "cs": "Hlas"
-    },
-    "Long Range Scanner": {
-      "es": "Escáner de Largo Alcance",
-      "pt": "Scanner de longo alcance",
-      "de": "Langstrecken-Scanner",
-      "fr": "Scanner Longue Portée",
-      "ru": "Сканер увеличенной дальности",
-      "pl": "Long Range Scanner",
-      "cs": "Long Range Scanner"
-    },
-    "Wide Angle Scanner": {
-      "es": null,
-      "pt": "Scanner de ângulo amplo",
-      "de": "Weitwinkel-Scanner",
-      "fr": "Scanner à Angle Large",
-      "ru": "Широкоугольный сканер",
-      "pl": "Wide Angle Scanner",
-      "cs": "Wide Angle Scanner"
-    },
-    "Light Weight Scanner": {
-      "es": null,
-      "pt": "Scanner leve",
-      "de": "Leichter Scanner",
-      "fr": "Scanner Léger",
-      "ru": "Облегченный сканер",
-      "pl": "Light Weight Scanner",
-      "cs": "Light Weight Scanner"
-    },
-    "Fast Scanner": {
-      "es": "Escáner Rápido",
-      "pt": "Scanner rápido",
-      "de": "Schneller Scanner",
-      "fr": "Scanner Rapide",
-      "ru": "Быстрый сканер",
-      "pl": "Fast Scanner",
-      "cs": "Fast Scanner"
-    },
-    "Unlock": {
-      "es": "Desbloquear",
-      "pt": "Desbloquear",
-      "de": "Freischalten",
-      "fr": "Déverrouiller",
-      "ru": "Расшифровка",
-      "pl": "Odblokowanie",
-      "cs": "Odemknutí"
-    },
-    "Available Voices:": {
-      "es": "Voces Disponibles",
-      "pt": "Vozes disponiveis",
-      "de": "verfügbare Stimmen",
-      "fr": "Voix Disponibles",
-      "ru": "Доступные голоса:",
-      "pl": "Dostępne głosy:",
-      "cs": "Dostupné hlasy:"
-    },
-    "filtered entries - click this to clear": {
-      "es": "entradas filtradas - haz clic aquí para limpiar",
-      "pt": "Entradas filtradas - Clique nela para limpar",
-      "de": "Gefilterte Einträge - Klick HIER um zu Löschen",
-      "fr": "entrées filtrées - cliquez ici pour nettoyer",
-      "ru": "отфильтрованные записи - нажмите для очистки",
-      "pl": null,
-      "cs": "Filtrované záznamy - klikni pro vyčistění"
-    },
-    "Thargoid Material Composition Data": {
-      "es": "Datos de Composición de Material Thargoide",
-      "pt": "Dados de composição de material Thargoid",
-      "de": "unbekannte Materialzusammensetzung",
-      "fr": "Donnée de Composition de Matérel Thargoid",
-      "ru": "Данные о составе таргоидских материалов",
-      "pl": null,
-      "cs": "Thargoid Material Composition Data"
-    },
-    "Thargoid Residue Data": {
-      "es": "Datos de Residuo Thargoide",
-      "pt": "Dados de resíduo Thargoid",
-      "de": "unbekannte Rückstandsdatenanalyse",
-      "fr": "Résidus de Données Thargoid",
-      "ru": "Данные об осадке таргоидского происхождения",
-      "pl": null,
-      "cs": "Thargoid Residue Data"
-    },
-    "Thargoid Structural Data": {
-      "es": "Datos Estructurales Thargoide",
-      "pt": "Dados de Estrutura Thargoid",
-      "de": "unbekannte Strukturdaten",
-      "fr": "Données Structurelles Thargoid",
-      "ru": "Данные о структуре таргоидского объекта",
-      "pl": null,
-      "cs": "Thargoid Structural Data"
-    },
-    "Thargoid Carapace": {
-      "es": null,
-      "pt": "Carapaça Thargoid",
-      "de": "unbekannte Panzerung",
-      "fr": "Carapace Thargoid",
-      "ru": "Таргоидский панцирь",
-      "pl": null,
-      "cs": "Thargoid Carapace"
-    },
-    "Thargoid Energy Cell": {
-      "es": "Célula de Energía Thargoide",
-      "pt": "Célula de Energia Thargoid",
-      "de": "unbekannte Energiezelle",
-      "fr": "Cellule d'Énergie Thargoid",
-      "ru": "Таргоидская энергоячейка",
-      "pl": null,
-      "cs": "Thargoid Energy Cell"
-    },
-    "Thargoid Organic Circuitry": {
-      "es": "Circuito Orgánico Thargoide",
-      "pt": "Circuito Orgânico Thargoid",
-      "de": "unbekannte organische Struktur",
-      "fr": "Circuit Organique Thargoid",
-      "ru": "Таргоидская органическая схема",
-      "pl": null,
-      "cs": "Thargoid Organic Circuitry"
-    },
-    "Thargoid Technological Components": {
-      "es": "Componentes Tecnológicos Thargoide",
-      "pt": "Componente Tecnológico Thargoid",
-      "de": "unbekannte Technologie-Komponente",
-      "fr": "Composants Technologique Thargoid",
-      "ru": "Компоненты таргоидской техники",
-      "pl": null,
-      "cs": "Thargoid Technological Components"
-    },
-    "Ship Flight Data": {
-      "es": null,
-      "pt": "Dados de voo da nave",
-      "de": "Schiff-Flug-Daten",
-      "fr": "Donnée de Vol",
-      "ru": "Полетные данные корабля",
-      "pl": null,
-      "cs": "Ship Flight Data"
-    },
-    "Ship System Data": {
-      "es": null,
-      "pt": "Dados do sistema da nave",
-      "de": "Schiff-System-Daten",
-      "fr": "Données de Système de Navigation",
-      "ru": "Данные бортовых систем корабля",
-      "pl": null,
-      "cs": "Ship System Data"
-    },
-    "Wreckage Components": {
-      "es": null,
-      "pt": "Destroços de componentes",
-      "de": "Wrackteile",
-      "fr": "Composants d'Épave",
-      "ru": "Обломки кораблекрушений",
-      "pl": null,
-      "cs": "Wreckage Components"
-    },
-    "Weapon Parts": {
-      "es": null,
-      "pt": "Partes de armas",
-      "de": "Waffenteile",
-      "fr": "Éléments d'Arme",
-      "ru": "Детали вооружения",
-      "pl": null,
-      "cs": "Weapon Parts"
-    },
-    "Bio-Mechanical Conduits": {
-      "es": "Conductos Bio-Mecánicos",
-      "pt": "Condutores Bio-mecânicos",
-      "de": "Bio-mechanische Leitungen",
-      "fr": "Conducteurs Bio-Mécanique",
-      "ru": "Биомеханические энергопроводники",
-      "pl": null,
-      "cs": "Bio-Mechanical Conduits"
-    },
-    "Propulsion Elements": {
-      "es": "Elementos de Propulsión",
-      "pt": "Elementos de Propulsão",
-      "de": "Antriebselemente",
-      "fr": "Elements de Propulsion",
-      "ru": "Реактивные элементы",
-      "pl": null,
-      "cs": "Propulsion Elements"
-    },
-    "Settings": {
-      "es": "Ajustes",
-      "pt": "Configurações",
-      "de": "Einstellungen",
-      "fr": "Paramètres",
-      "ru": "Настройки",
-      "pl": null,
-      "cs": "Nastavení"
-    },
-    "Configure Graphics": {
-      "es": "Ajustes Gráficos",
-      "pt": "Configurar gráficos",
-      "de": "Grafik einstellen",
-      "fr": "Configuration Graphique",
-      "ru": "Настройки графики",
-      "pl": null,
-      "cs": "Nastav grafiku"
-    },
-    "100% Refill": {
-      "es": "100% de Recarga",
-      "pt": "100% de Recarga",
-      "de": "100% Nachfüllung",
-      "fr": "100% de Recharge",
-      "ru": "100% заправка",
-      "pl": null,
-      "cs": "100% doplnění"
-    },
-    "100% Refill, +15% Heat Dissipation": {
-      "es": "100% de Recarga, +15% de Disipación de Calor",
-      "pt": "100% de Recarga, +15% de Dissipação de Calor",
-      "de": "100% Nachfüllung, +15% Wärmeableitung",
-      "fr": "100% de Recharge, +15% de Dissipation de Chaleur",
-      "ru": "100% заправка, +15% рассеивание тепла",
-      "pl": null,
-      "cs": "100% doplnění, +15% odvod tepla"
-    },
-    "100% Refill, +2 Seconds Duration": {
-      "es": "100% de Recarga, +2 Segundos de Duración",
-      "pt": "100% de Recarga, +2 Segundos de Duração",
-      "de": "100% Nachfüllung, +2 Sekunden Dauer",
-      "fr": "100% de Recharge, +2 Secondes de Durée",
-      "ru": "100% заправка, +2 секунды действия",
-      "pl": null,
-      "cs": "100% doplnění, +2 sekundy k trvání"
-    },
-    "100% Refill, +30% Heat Dissipation": {
-      "es": "100% de Recarga, +30% de Disipación de Calor",
-      "pt": "100% de Recarga, +30% de Dissipação de Calor",
-      "de": "100% Nachfüllung, +30% Wärmeableitung",
-      "fr": "100% de Recharge, +30% de Dissipation de Chaleur",
-      "ru": "100% заправка, +30% рассеивание тепла",
-      "pl": null,
-      "cs": "100% doplnění, +30% odvod tepla"
-    },
-    "4 Limpets, Cargo Hold Required": {
-      "es": "4 Drones, Espacio de Carga Necesario",
-      "pt": "4 Drones, Porão de Carga Necessário ",
-      "de": "für Drohnen, Laderaum erforderlich",
-      "fr": "4 Drones, Soute Requise",
-      "ru": "4 беспилотника, необходим грузовой отсек",
-      "pl": null,
-      "cs": "4 Limpety, Vyžadován nákladový prostor (cargo)"
-    },
-    "50% Refill": {
-      "es": "50% de Recarga",
-      "pt": "50% de Recarga",
-      "de": "50% Nachfüllung",
-      "fr": "50% de Recharge",
-      "ru": "50% заправка",
-      "pl": null,
-      "cs": "50% doplnění"
-    },
-    "Fujin Tea": {
-      "es": "Té de Fujin",
-      "pt": "Chá de Fujin",
-      "de": "Fujin-Tee",
-      "fr": "Thé Fujin",
-      "ru": "Чай Fujin",
-      "pl": null,
-      "cs": "Fujin Tea"
-    },
-    "Gold": {
-      "es": "Oro",
-      "pt": "Ouro",
-      "de": "Gold",
-      "fr": "Or",
-      "ru": "Золото",
-      "pl": null,
-      "cs": "Gold"
-    },
-    "Kamitra Cigars": {
-      "es": null,
-      "pt": "Charutos de Kamitra",
-      "de": "Kamitra-Zigarren",
-      "fr": "Cigares de Kamitra",
-      "ru": "Сигары Kamitra",
-      "pl": null,
-      "cs": "Kamitra Cigars"
-    },
-    "Kongga Ale": {
-      "es": "Cerveza de Kongga",
-      "pt": "Cerveja de Kongga",
-      "de": "Kongga-Bier",
-      "fr": "Bière de Kongga",
-      "ru": "Эль Конгга",
-      "pl": null,
-      "cs": "Kongga Ale"
-    },
-    "Landmines": {
-      "es": "Minas Terrestres",
-      "pt": "Minas Terrestres",
-      "de": "Landminen",
-      "fr": "Mines Terrestres",
-      "ru": "Мины",
-      "pl": null,
-      "cs": "Landmines"
-    },
-    "Lavian Brandy": {
-      "es": "Brandy Laviano",
-      "pt": "Brandy Laviano",
-      "de": "Lave-Brandy",
-      "fr": "Cognac Lavien",
-      "ru": "Лавианский бренди",
-      "pl": null,
-      "cs": "Lavian Brandy"
-    },
-    "Limpets": {
-      "es": "Drones",
-      "pt": "Drones",
-      "de": "Drohnen",
-      "fr": "Drones",
-      "ru": "Беспилотники",
-      "pl": null,
-      "cs": "Limpety"
-    },
-    "Meta-alloys": {
-      "es": "Meta-aleaciones",
-      "pt": "Meta-Ligas",
-      "de": "Meta-Legierungen",
-      "fr": "Meta-Alliages",
-      "ru": "Метасплавы",
-      "pl": null,
-      "cs": "Meta-alloys"
-    },
-    "Painite": {
-      "es": null,
-      "pt": "Painita",
-      "de": "Painit",
-      "fr": "Painite",
-      "ru": "Пейнит",
-      "pl": null,
-      "cs": "Painite"
-    },
-    "Soontill Relics": {
-      "es": "Reliquias de Soontill",
-      "pt": "Relíquias de Soontill",
-      "de": "Soontil Relikte",
-      "fr": "Relique de Soontill",
-      "ru": "Реликты Сунтилла",
-      "pl": null,
-      "cs": "Soontill Relics"
-    },
-    "Xihe Companions": {
-      "es": null,
-      "pt": "Companheiros Xihe",
-      "de": "Haustiere von Xihe",
-      "fr": "Compagnions Xihe",
-      "ru": "Спутники Xihe",
-      "pl": null,
-      "cs": "Xihe Companions"
-    },
-    "Raw": {
-      "es": null,
-      "pt": "Bruto",
-      "de": "roh",
-      "fr": "À l'état brut",
-      "ru": "Неочищенные минералы",
-      "pl": null,
-      "cs": "Surové (Raw)"
-    },
-    "Raw Only": {
-      "es": null,
-      "pt": "Apenas Bruto",
-      "de": "nur roh",
-      "fr": "Uniquement à l'état brut",
-      "ru": "Только неочищенные минералы",
-      "pl": null,
-      "cs": "Pouze surové(Raw only)"
-    },
-    "Manufactured": {
-      "es": "Manufacturado(s)",
-      "pt": "Fabricado",
-      "de": "hergestellt",
-      "fr": "Manufacturé(s)",
-      "ru": "Компоненты",
-      "pl": null,
-      "cs": "Vyrobené(Manufactured)"
-    },
-    "Manufactured Only": {
-      "es": "Solo manufacturado(s)",
-      "pt": "Apenas Fabricado",
-      "de": "nur hergestellt",
-      "fr": "Uniquement manufacturé(s)",
-      "ru": "Только компоненты",
-      "pl": null,
-      "cs": "Pouze vyrobené(Manufact.only)"
-    },
-    "Unrecognized Ingredient (showing name as it appears in the logs). Please open a GitHub issue to let the author know what is the real name of this!": {
-      "es": "Ingrediente no reconocido (mostrando el nombre como aparece en los logs). Por favor abra un asunto en GitHub para notificar al autor cuál es el nombre real the este ingrediente!",
-      "pt": "Ingrediente não reconhecido (mostrando o nome como aparece nos registros). Abra um problema do GitHub para que o autor saiba qual é o nome verdadeiro disso!",
-      "de": "Unbekannter Bestandteil (zeigt den Namen, wie er in den Protokollen erscheint). Bitte öffnen Sie ein GitHub-Issue, um den Autor wissen zu lassen, wie dieser wirklich heißt!",
-      "fr": null,
-      "ru": "Нераспознанный ингредиент (отображается название из логов). Пожалуйста, создайте issue на GitHub, чтобы оповестить разработчика о фактическом названии!",
-      "pl": null,
-      "cs": "Nerozpoznaná ingredience (Zobrazené jméno je tak, jak se vyskytuje v logu). Prosím otevřete požadavek na GitHubu a dejte vědět autorovi správný název ingredience!"
-    },
-    "Group ingredients?": {
-      "es": "Grupo de ingredientes?",
-      "pt": null,
-      "de": "Gruppenzutaten?",
-      "fr": "Groupe d'ingrédients ?",
-      "ru": "Группировать ингредиенты?",
-      "pl": null,
-      "cs": "Seskupovat ingredience?"
-    },
-    "Unknown": {
-      "es": "Desconocido",
-      "pt": "Desconhecido",
-      "de": "Unbekannt",
-      "fr": "Inconnu",
-      "ru": "Неизвестные",
-      "pl": null,
-      "cs": "Neznámé"
-    },
-    "Carrying ": {
-      "es": "Transportando",
-      "pt": null,
-      "de": "Trasportieren ",
-      "fr": "Capacité",
-      "ru": "В наличии ",
-      "pl": null,
-      "cs": "Vlastněno "
-    },
-    "Emission Data": {
-      "es": "Datos de emisión",
-      "pt": null,
-      "de": "Emissionsdaten",
-      "fr": "Données d'émission",
-      "ru": "Данные об излучениях",
-      "pl": null,
-      "cs": "Emission Data"
-    },
-    "Wake Scans": {
-      "es": "Escaneos de estela",
-      "pt": null,
-      "de": "Sogwolken Scans",
-      "fr": "Données de sillages",
-      "ru": "Сканирования следа FSD",
-      "pl": null,
-      "cs": "Wake Scans"
-    },
-    "Shield Data": {
-      "es": "Datos de escudo",
-      "pt": null,
-      "de": "Schilddaten",
-      "fr": "Données de bouclier",
-      "ru": "Данные о щитах",
-      "pl": null,
-      "cs": "Shield Data"
-    },
-    "Encryption Files": {
-      "es": "Archivos de encriptación",
-      "pt": null,
-      "de": "Verschlüsselungsdaten",
-      "fr": "Fichiers cryptés",
-      "ru": "Файлы шифрования",
-      "pl": null,
-      "cs": "Encryption Files"
-    },
-    "Data Archives": {
-      "es": "Archivos de datos",
-      "pt": null,
-      "de": "Datenarchive",
-      "fr": "Archives de données",
-      "ru": "Архивы данных",
-      "pl": null,
-      "cs": "Data Archives"
-    },
-    "Encoded Firmware": {
-      "es": null,
-      "pt": null,
-      "de": "Codierte Firmware",
-      "fr": "Micrologiciels encodés",
-      "ru": "Закодированные микропрограммы",
-      "pl": null,
-      "cs": "Encoded Firmware"
-    },
-    "Category 1": {
-      "es": "Categoría 1",
-      "pt": "Categoria 1",
-      "de": "Kategorie 1",
-      "fr": "Matériaux bruts - Catégorie 1",
-      "ru": "Категория 1",
-      "pl": null,
-      "cs": "Kategorie 1"
-    },
-    "Category 2": {
-      "es": "Categoría 2",
-      "pt": "Categoria 2",
-      "de": "Kategorie 2",
-      "fr": "Matériaux bruts - Catégorie 2",
-      "ru": "Категория 2",
-      "pl": null,
-      "cs": "Kategorie 2"
-    },
-    "Category 3": {
-      "es": "Categoría 3",
-      "pt": "Categoria 3",
-      "de": "Kategorie 3",
-      "fr": "Matériaux bruts - Catégorie 3",
-      "ru": "Категория 3",
-      "pl": null,
-      "cs": "Kategorie 3"
-    },
-    "Category 4": {
-      "es": "Categoría 4",
-      "pt": "Categoria 4",
-      "de": "Kategorie 4",
-      "fr": "Matériaux bruts - Catégorie 4",
-      "ru": "Категория 4",
-      "pl": null,
-      "cs": "Kategorie 4"
-    },
-    "Category 5": {
-      "es": "Categoría 5",
-      "pt": "Categoria 5",
-      "de": "Kategorie 5",
-      "fr": "Matériaux bruts - Catégorie 5",
-      "ru": "Категория 5",
-      "pl": null,
-      "cs": "Kategorie 5"
-    },
-    "Category 6": {
-      "es": "Categoría 6",
-      "pt": "Categoria 6",
-      "de": "Kategorie 6",
-      "fr": "Matériaux bruts - Catégorie 6",
-      "ru": "Категория 6",
-      "pl": null,
-      "cs": "Kategorie 6"
-    },
-    "Category 7": {
-      "es": "Categoría 7",
-      "pt": "Categoria 7",
-      "de": "Kategorie 7",
-      "fr": "Matériaux bruts - Catégorie 7",
-      "ru": "Категория 7",
-      "pl": null,
-      "cs": "Kategorie 7"
-    },
-    "Chemical": {
-      "es": "Químico",
-      "pt": null,
-      "de": "Chemikalien",
-      "fr": "Produits chimiques",
-      "ru": "Химикаты",
-      "pl": null,
-      "cs": "Chemické (Chemical)"
-    },
-    "Thermic": {
-      "es": "Térmico",
-      "pt": "Térmico",
-      "de": "Thermisch",
-      "fr": "Thermiques",
-      "ru": "Термические сплавы",
-      "pl": null,
-      "cs": "Termické (Thermic)"
-    },
-    "Heat": {
-      "es": "Calor",
-      "pt": null,
-      "de": "Hitze",
-      "fr": "Chaleur",
-      "ru": "Теплообмен",
-      "pl": null,
-      "cs": "Tepelné (Heat)"
-    },
-    "Conductive": {
-      "es": "Conductivo",
-      "pt": null,
-      "de": "Leiter",
-      "fr": "Conducteurs",
-      "ru": "Проводники",
-      "pl": null,
-      "cs": "Konduktivní (Conductive)"
-    },
-    "Capacitors": {
-      "es": "Condensadores",
-      "pt": null,
-      "de": "Kondensatoren",
-      "fr": "Condensateurs",
-      "ru": "Конденсаторы",
-      "pl": null,
-      "cs": "Kondenzátory (Capacitors)"
-    },
-    "Shielding": {
-      "es": "Protección",
-      "pt": null,
-      "de": "Abschirmung",
-      "fr": "Protection",
-      "ru": "Защита",
-      "pl": null,
-      "cs": "Stínění (Shielding)"
-    },
-    "Composite": {
-      "es": "Compuesto",
-      "pt": null,
-      "de": "Komposite",
-      "fr": "Composites",
-      "ru": "Композиты",
-      "pl": null,
-      "cs": "Kompozity (Composite)"
-    },
-    "Crystals": {
-      "es": "Cristales",
-      "pt": null,
-      "de": "Kristalle",
-      "fr": "Cristaux",
-      "ru": "Кристаллы",
-      "pl": null,
-      "cs": "Krystaly (Crystals)"
-    },
-    "Alloys": {
-      "es": "Aleaciones",
-      "pt": "Ligas",
-      "de": "Legierungen",
-      "fr": "Alliages",
-      "ru": "Сплавы",
-      "pl": null,
-      "cs": "Slitiny (Alloys)"
-    },
-    "Lead": {
-      "es": "Plomo",
-      "pt": "Chumbo",
-      "de": "Blei",
-      "fr": null,
-      "ru": "Свинец",
-      "pl": null,
-      "cs": "Lead"
-    },
-    "Boron": {
-      "es": "Boro",
-      "pt": "Boro",
-      "de": "Bor",
-      "fr": null,
-      "ru": "Бор",
-      "pl": null,
-      "cs": "Boron"
-    },
-    "Guardian Weapon Blueprint Segment": {
-      "es": null,
-      "pt": "Segmento de Diagrama de Arma Guardian",
-      "de": "Guardian-Waffenbauplansegment",
-      "fr": null,
-      "ru": "Фрагмент чертежа оружия стражей",
-      "pl": null,
-      "cs": "Guardian Weapon Blueprint Segment"
-    },
-    "Guardian Power Cell": {
-      "es": null,
-      "pt": "Bateria Guardian",
-      "de": "Guardian-Energiezelle",
-      "fr": null,
-      "ru": "Энергоячейка стражей",
-      "pl": null,
-      "cs": "Guardian Power Cell"
-    },
-    "Guardian Technology Component": {
-      "es": null,
-      "pt": "Componente de Tecnologia Guardian",
-      "de": "Guardian-Technologiekomponente",
-      "fr": null,
-      "ru": "Компоненты технологий стражей",
-      "pl": null,
-      "cs": "Guardian Technology Component"
-    },
-    "Guardian Power Conduit": {
-      "es": null,
-      "pt": "Condutores de Potência Guardian",
-      "de": "Guardian-Energieleiter",
-      "fr": null,
-      "ru": "Энергопроводники стражей",
-      "pl": null,
-      "cs": "Guardian Power Conduit"
-    },
-    "Guardian Sentinel Weapon Parts": {
-      "es": null,
-      "pt": "Peças de Armas Sentinela Guardian",
-      "de": "Guardian-Wache-Waffenteile",
-      "fr": null,
-      "ru": "Детали вооружения стража Sentinel",
-      "pl": null,
-      "cs": "Guardian Sentinel Weapon Parts"
-    },
-    "Guardian Module Blueprint Segment": {
-      "es": null,
-      "pt": "Segmento de Diagrama de Módulo Guardian",
-      "de": "Guardian-Modulbauplansegment",
-      "fr": null,
-      "ru": "Фрагмент чертежа модуля стражей",
-      "pl": null,
-      "cs": "Guardian Module Blueprint Segment"
-    },
-    "Guardian Sentinel Wreckage Components": {
-      "es": null,
-      "pt": "Componentes de Destroços Sentinela Guardian",
-      "de": "Guardian-Wache Trümmerteile",
-      "fr": null,
-      "ru": "Обломки кораблекрушений стража Sentinel",
-      "pl": null,
-      "cs": "Guardian Sentinel Wreckage Components"
-    },
-    "Guardian Vessel Blueprint Segment": {
-      "es": null,
-      "pt": null,
-      "de": "Guardian-Schiffsbauplansegment",
-      "fr": null,
-      "ru": "Фрагмент чертежа судна стражей",
-      "pl": null,
-      "cs": "Guardian Vessel Blueprint Segment"
-    },
-    "Human": {
-      "es": "Humano",
-      "pt": "Humano",
-      "de": "Menschlich",
-      "fr": null,
-      "ru": "Технологии людей",
-      "pl": null,
-      "cs": "Lidské"
-    },
-    "Corrosion Resistant Cargo Rack (2D and 4D)": {
-      "es": "Bodega de carga resistente a corrosión (2D y 4D)",
-      "pt": "Estante de Carga Anti-Corrosiva (2D e 4D)",
-      "de": "Korrosionsresistentes Frachtegtell (2D and 4D)",
-      "fr": null,
-      "ru": "Коррозийно-устойчивый грузовой стеллаж (2D и 4D)",
-      "pl": null,
-      "cs": "Corrosion Resistant Cargo Rack (2D and 4D)"
-    },
-    "Enzyme Missile Rack": {
-      "es": null,
-      "pt": "Estante de Mísseis Enzimáticos",
-      "de": "Enzym Raketenrampe",
-      "fr": null,
-      "ru": "Блок энзимных ракет",
-      "pl": null,
-      "cs": "Enzyme Missile Rack"
-    },
-    "Guardian": {
-      "es": "Guardián",
-      "pt": "Guardian",
-      "de": "Guardian",
-      "fr": null,
-      "ru": "Технологии стражей",
-      "pl": null,
-      "cs": "Guardiánské"
-    },
-    "Guardian Gauss Cannon (Fixed)": {
-      "es": "Cañón Gauss Guardián (Fijo)",
-      "pt": "Canhão Gauss Guardian (Fixa)",
-      "de": "Guardian-Gausskannone (Fest)",
-      "fr": "Canon de gauss - Guardians (Fixe)",
-      "ru": "Пушка Гаусса стражей (фиксированное)",
-      "pl": null,
-      "cs": "Guardian Gauss Cannon (Fixed)"
-    },
-    "Guardian Plasma Charger (Fixed)": {
-      "es": "Cargador de Plasma Guardián (Fijo)",
-      "pt": "Carregador de Plasma Guardian (Fixa)",
-      "de": "Guardian-Plasmalader (Fest)",
-      "fr": "Chargeur à plasma - Guardians (Fixe)",
-      "ru": "Плазменная пушка стражей (фиксированное)",
-      "pl": null,
-      "cs": "Guardian Plasma Charger (Fixed)"
-    },
-    "Guardian Plasma Charger (Turreted)": {
-      "es": "Cargador de Plasma Guardián (Torreta)",
-      "pt": "Carregador de Plasma Guardian (Torretada)",
-      "de": "Guardian-Plasmalader (Turm)",
-      "fr": "Chargeur à plasma - Guardians (Tourelle)",
-      "ru": "Плазменная пушка стражей (турель)",
-      "pl": null,
-      "cs": "Guardian Plasma Charger (Turreted)"
-    },
-    "Guardian Hybrid Power Plant": {
-      "es": "Núcleo de energía Guardián",
-      "pt": "Gerador de Energia Guardian",
-      "de": "Guardian-Kraftwerk",
-      "fr": "Générateur - Guardians",
-      "ru": "Силовая установка стражей",
-      "pl": null,
-      "cs": "Guardian Hybrid Power Plant"
-    },
-    "Meta Alloy Hull Reinforcement": {
-      "es": null,
-      "pt": null,
-      "de": "Meta-Legierung-Hüllenverstärkung",
-      "fr": null,
-      "ru": "Метасплавное усиление корпуса",
-      "pl": null,
-      "cs": "Meta Alloy Hull Reinforcement"
-    },
-    "Remote Release Flechette Launcher (Fixed)": {
-      "es": null,
-      "pt": "Lançador de dardos de Liberação Remota (Fixa)",
-      "de": "ferngesteuerter Flechettenwerfer (Fest)",
-      "fr": null,
-      "ru": "Зенитная установка с дистанционным подрывом (фиксированное)",
-      "pl": null,
-      "cs": "Remote Release Flechette Launcher (Fixed)"
-    },
-    "Remote Release Flechette Launcher (Turreted)": {
-      "es": null,
-      "pt": "Lançador de dardos de Liberação Remota (Torretada)",
-      "de": "ferngesteuerter Flechettenwerfer (Turm)",
-      "fr": null,
-      "ru": "Зенитная установка с дистанционным подрывом (турель)",
-      "pl": null,
-      "cs": "Remote Release Flechette Launcher (Turreted)"
-    },
-    "Shock Cannon (Fixed)": {
-      "es": "Cañon de choque (Fijo)",
-      "pt": "Canhão Elétrico (Fixa)",
-      "de": "Schock Kanone (Fest)",
-      "fr": null,
-      "ru": "Шоковое орудие (фиксированное)",
-      "pl": null,
-      "cs": "Shock Cannon (Fixed)"
-    },
-    "Shock Cannon (Gimballed)": {
-      "es": "Cañon de choque (Guiado)",
-      "pt": "Canhão Elétrico (Guiada)",
-      "de": "Schock Kanone (Kardanisch)",
-      "fr": null,
-      "ru": "Шоковое орудие (на карданной подвеске)",
-      "pl": null,
-      "cs": "Shock Cannon (Gimballed)"
-    },
-    "Shock Cannon (Turreted)": {
-      "es": "Cañon de choque (Torreta)",
-      "pt": "Canhão Elétrico (Torretada)",
-      "de": "Schock Kanone (Turm)",
-      "fr": null,
-      "ru": "Шоковое орудие (турель)",
-      "pl": null,
-      "cs": "Shock Cannon (Turreted)"
-    },
-    "Concordant Sequence": {
-      "es": "Secuencia Concordante",
-      "pt": null,
-      "de": "gleichsinnige Sequenz",
-      "fr": null,
-      "ru": "Последовательность координации",
-      "pl": null,
-      "cs": "Concordant Sequence"
-    },
-    "Regeneration Sequence": {
-      "es": "Secuencia de Regeneración",
-      "pt": null,
-      "de": "regenerierende Sequenz",
-      "fr": null,
-      "ru": "Последовательность восстановления",
-      "pl": null,
-      "cs": "Regeneration Sequence"
-    },
-    "Thermal Conduit": {
-      "es": "Conductor Térmico",
-      "pt": null,
-      "de": "Hitzerohr",
-      "fr": null,
-      "ru": "Проводник тепла",
-      "pl": null,
-      "cs": "Thermal Conduit"
-    },
-    "Thermal Shock": {
-      "es": "Choque Térmico",
-      "pt": null,
-      "de": "Thermischer Schock",
-      "fr": null,
-      "ru": "Тепловой удар",
-      "pl": null,
-      "cs": "Thermal Shock"
-    },
-    "Thermal Vent": {
-      "es": "Respiradero Térmico",
-      "pt": null,
-      "de": "Thermische Entlastung",
-      "fr": null,
-      "ru": "Теплоотдача",
-      "pl": null,
-      "cs": "Thermal Vent"
-    },
-    "Oversized": {
-      "es": "Sobredimensionado",
-      "pt": null,
-      "de": "Übergröße",
-      "fr": null,
-      "ru": "Сверхразмер",
-      "pl": null,
-      "cs": "Oversized"
-    },
-    "Stripped Down": {
-      "es": "Despojado",
-      "pt": null,
-      "de": "Reduktion",
-      "fr": null,
-      "ru": "Урезанный вариант",
-      "pl": null,
-      "cs": "Stripped Down"
-    },
-    "Double Braced": {
-      "es": null,
-      "pt": null,
-      "de": "Doppelt Versteift",
-      "fr": null,
-      "ru": "Двойная прочность",
-      "pl": null,
-      "cs": "Double Braced"
-    },
-    "Flow Control": {
-      "es": null,
-      "pt": null,
-      "de": "Flusssteuerung",
-      "fr": null,
-      "ru": "Контроль интенсивности",
-      "pl": null,
-      "cs": "Flow Control"
-    },
-    "Inertial Impact": {
-      "es": "Impacto Inercial",
-      "pt": null,
-      "de": "Trägheitseinfluss",
-      "fr": null,
-      "ru": "Инерционный удар",
-      "pl": null,
-      "cs": "Inertial Impact"
-    },
-    "Phasing Sequence": {
-      "es": null,
-      "pt": null,
-      "de": "Phasensequenz",
-      "fr": null,
-      "ru": "Последовательность фазирования",
-      "pl": null,
-      "cs": "Phasing Sequence"
-    },
-    "Scramble Spectrum": {
-      "es": null,
-      "pt": null,
-      "de": "Mischungsbandbreite",
-      "fr": null,
-      "ru": "Отключающая сетка",
-      "pl": null,
-      "cs": "Scramble Spectrum"
-    },
-    "Multi-Servos": {
-      "es": null,
-      "pt": null,
-      "de": "Multi-Servos",
-      "fr": null,
-      "ru": "Сервосистема",
-      "pl": null,
-      "cs": "Multi-Servos"
-    },
-    "Emissive Munitions": {
-      "es": null,
-      "pt": null,
-      "de": "Emissionsgranate",
-      "fr": null,
-      "ru": "Эмиссионные припасы",
-      "pl": null,
-      "cs": "Emissive Munitions"
-    },
-    "Auto Loader": {
-      "es": "Cargador automático",
-      "pt": null,
-      "de": "Auto-Laden",
-      "fr": null,
-      "ru": "Автоматическая система заряжания",
-      "pl": null,
-      "cs": "Auto Loader"
-    },
-    "Corrosive Shell": {
-      "es": null,
-      "pt": null,
-      "de": "Korrosionsgranate",
-      "fr": null,
-      "ru": "Разъедающие боеприпасы",
-      "pl": null,
-      "cs": "Corrosive Shell"
-    },
-    "Incendiary Rounds": {
-      "es": "Rondas Incendiarias",
-      "pt": null,
-      "de": "Hitzesalven",
-      "fr": null,
-      "ru": "Зажигательные припасы",
-      "pl": null,
-      "cs": "Incendiary Rounds"
-    },
-    "Smart Rounds": {
-      "es": "Rondas Inteligentes",
-      "pt": null,
-      "de": "Intelligente Munition",
-      "fr": null,
-      "ru": "Умные боеприпасы",
-      "pl": null,
-      "cs": "Smart Rounds"
-    },
-    "Dispersal Field": {
-      "es": "Campo de Dispersión",
-      "pt": null,
-      "de": "Streuungsfeld",
-      "fr": null,
-      "ru": "Рассеивающее поле",
-      "pl": null,
-      "cs": "Dispersal Field"
-    },
-    "Force Shell": {
-      "es": "Escudo de Fuerza",
-      "pt": null,
-      "de": "Impulsgranate",
-      "fr": null,
-      "ru": "Усиленные снаряды",
-      "pl": null,
-      "cs": "Force Shell"
-    },
-    "High Yield Shell": {
-      "es": null,
-      "pt": null,
-      "de": "Hocheffizienzgranate",
-      "fr": null,
-      "ru": "Снаряды большой мощности",
-      "pl": null,
-      "cs": "High Yield Shell"
-    },
-    "Thermal Cascade": {
-      "es": "Cascada Térmica",
-      "pt": null,
-      "de": "Thermalkaskade",
-      "fr": null,
-      "ru": "Термический залп",
-      "pl": null,
-      "cs": "Thermal Cascade"
-    },
-    "Dazzle Shell": {
-      "es": null,
-      "pt": null,
-      "de": "Blendgranate",
-      "fr": null,
-      "ru": "Ослепляющие снаряды",
-      "pl": null,
-      "cs": "Dazzle Shell"
-    },
-    "Drag Munition": {
-      "es": null,
-      "pt": null,
-      "de": "Ableitungsmunition",
-      "fr": null,
-      "ru": "Замедляющие боеприпасы",
-      "pl": null,
-      "cs": "Drag Munition"
-    },
-    "Screening Shell": {
-      "es": null,
-      "pt": null,
-      "de": "Sperrgranate",
-      "fr": null,
-      "ru": "Заслоняющие снаряды",
-      "pl": null,
-      "cs": "Screening Shell"
-    },
-    "Drag Munition (Seeker only)": {
-      "es": null,
-      "pt": null,
-      "de": "Ableitungsmunition (nur Suchraketen)",
-      "fr": null,
-      "ru": "Замедляющие боеприпасы (лоток с самонаведением)",
-      "pl": null,
-      "cs": "Drag Munition (Seeker only)"
-    },
-    "Overload Munitions": {
-      "es": null,
-      "pt": null,
-      "de": "Überladungsmunition",
-      "fr": null,
-      "ru": "Вызывающие перегрузку боеприпасы",
-      "pl": null,
-      "cs": "Overload Munitions"
-    },
-    "Penetrator Munitions (Dumbfire only)": {
-      "es": null,
-      "pt": null,
-      "de": "Penetrationsmunition",
-      "fr": null,
-      "ru": "Бронебойные боеголовки",
-      "pl": null,
-      "cs": "Penetrator Munitions (Dumbfire only)"
-    },
-    "FSD Interrupt (Dumbfire only)": {
-      "es": null,
-      "pt": null,
-      "de": "FSA-Unterbrechung (nur Dumbfire)",
-      "fr": null,
-      "ru": "Помеха для FSD",
-      "pl": null,
-      "cs": "FSD Interrupt (Dumbfire only)"
-    },
-    "Mass Lock Munition": {
-      "es": null,
-      "pt": null,
-      "de": "Massesperremunition",
-      "fr": null,
-      "ru": "Боеприпасы с гравитационным захватом",
-      "pl": null,
-      "cs": "Mass Lock Munition"
-    },
-    "Penetrator Payload": {
-      "es": null,
-      "pt": null,
-      "de": "Penetrationsmunition",
-      "fr": null,
-      "ru": "Бронебойные снаряды",
-      "pl": null,
-      "cs": "Penetrator Payload"
-    },
-    "Reverberating Cascade": {
-      "es": null,
-      "pt": null,
-      "de": "Rückstrahlkaskade",
-      "fr": null,
-      "ru": "Отраженный залп",
-      "pl": null,
-      "cs": "Reverberating Cascade"
-    },
-    "Ion Disruptor": {
-      "es": null,
-      "pt": null,
-      "de": "Ionen-Disruption",
-      "fr": null,
-      "ru": "Ионный дестабилизатор",
-      "pl": null,
-      "cs": "Ion Disruptor"
-    },
-    "Radiant Canister": {
-      "es": null,
-      "pt": null,
-      "de": "Strahlenbehältnis",
-      "fr": null,
-      "ru": "Светящаяся кассета",
-      "pl": null,
-      "cs": "Radiant Canister"
-    },
-    "Shift-Lock Canister": {
-      "es": null,
-      "pt": null,
-      "de": "Frameshift-Blocker",
-      "fr": null,
-      "ru": "Рамоблокирующая кассета",
-      "pl": null,
-      "cs": "Shift-Lock Canister"
-    },
-    "Target Lock Breaker": {
-      "es": null,
-      "pt": null,
-      "de": null,
-      "fr": null,
-      "ru": "Генератор помех для системы захвата цели",
-      "pl": null,
-      "cs": "Target Lock Breaker"
-    },
-    "Plasma Slug": {
-      "es": null,
-      "pt": null,
-      "de": "Plasmaprojektil",
-      "fr": null,
-      "ru": "Плазменный рельсовый заряд",
-      "pl": null,
-      "cs": "Plasma Slug"
-    },
-    "Feedback Cascade": {
-      "es": null,
-      "pt": null,
-      "de": "Rückkopplungskaskade",
-      "fr": null,
-      "ru": "Ответный залп",
-      "pl": null,
-      "cs": "Feedback Cascade"
-    },
-    "Super Penetrator": {
-      "es": null,
-      "pt": null,
-      "de": "Super-Durchdringer",
-      "fr": null,
-      "ru": "Модуль сверхпробития",
-      "pl": null,
-      "cs": "Super Penetrator"
-    },
-    "@Technology": {
-      "es": "@Tecnología",
-      "pt": null,
-      "de": "@Technologie",
-      "fr": null,
-      "ru": "@Технология",
-      "pl": null,
-      "cs": "@Technologie"
-    },
-    "Module": {
-      "es": "Módulo",
-      "pt": "Módulo",
-      "de": "Module",
-      "fr": null,
-      "ru": "Модули",
-      "pl": null,
-      "cs": "Moduly"
-    },
-    "Synthesis": {
-      "es": "Síntesis",
-      "pt": null,
-      "de": "Synthese",
-      "fr": null,
-      "ru": "Синтез",
-      "pl": null,
-      "cs": "Syntéza"
-    },
-    "Experimental": {
-      "es": "Experimental",
-      "pt": "Experimental",
-      "de": "Experimentell",
-      "fr": null,
-      "ru": "Экспериментальные",
-      "pl": null,
-      "cs": "Experimentální"
-    },
-    "Technology": {
-      "es": "Tecnología",
-      "pt": null,
-      "de": "Technologie",
-      "fr": null,
-      "ru": "Технологии",
-      "pl": null,
-      "cs": "Technologie"
-    },
-    "Ancient/Guardian ruins": {
-      "es": "Ruinas Antíguas/Guardianes",
-      "pt": null,
-      "de": "Uralte/Guardian Ruinen",
-      "fr": null,
-      "ru": "Руины стражей",
-      "pl": null,
-      "cs": "Starobylé/Guardiánské ruiny"
-    },
-    "EDEngineer will try to remove blueprints from your shopping list if you craft them in game": {
-      "es": "EDEngineer intentará eliminar planos de tu lista si los creas en el juego",
-      "pt": null,
-      "de": "EDEngineer wird versuchen, Blaupausen von Ihrer Einkaufsliste zu entfernen, wenn Sie sie im Spiel erstellen.",
-      "fr": null,
-      "ru": "EDEngineer попытается удалять чертежи из списка покупок при создании их в игре",
-      "pl": null,
-      "cs": "EDEngineer se pokusí odebrat plánky z vašeho nákupního seznamu, když je aplikujete ve hře"
-    },
-    "Thermal Spread": {
-      "es": null,
-      "pt": null,
-      "de": "Wärmeverteilung",
-      "fr": null,
-      "ru": "Рассеивание тепла",
-      "pl": null,
-      "cs": "Thermal Spread"
-    },
-    "Monstered": {
-      "es": null,
-      "pt": null,
-      "de": "monströs",
-      "fr": null,
-      "ru": "Монстрация",
-      "pl": null,
-      "cs": "Monstered"
-    },
-    "Angled Plating": {
-      "es": "Blindaje Angulado",
-      "pt": null,
-      "de": "Abgewinkelte Beschichtung",
-      "fr": null,
-      "ru": "Угловая броня",
-      "pl": null,
-      "cs": "Angled Plating"
-    },
-    "Layered Plating": {
-      "es": "Blindaje Compuesto",
-      "pt": null,
-      "de": "Mehrschichtige Beschichtung",
-      "fr": null,
-      "ru": "Многослойная броня",
-      "pl": null,
-      "cs": "Layered Plating"
-    },
-    "Reflective Plating": {
-      "es": "Blindaje Reflectante",
-      "pt": null,
-      "de": "Reflektierende Beschichtung",
-      "fr": null,
-      "ru": "Отражающая броня",
-      "pl": null,
-      "cs": "Reflective Plating"
-    },
-    "Deep Plating": {
-      "es": "Blindaje Profundo",
-      "pt": null,
-      "de": "Tiefenüberzug",
-      "fr": null,
-      "ru": "Утолщенная броня",
-      "pl": null,
-      "cs": "Deep Plating"
-    },
-    "Boss Cells": {
-      "es": null,
-      "pt": null,
-      "de": "Boss-Zellen",
-      "fr": null,
-      "ru": "Босс-ячейки",
-      "pl": null,
-      "cs": "Boss Cells"
-    },
-    "Recycling Cells": {
-      "es": "Celdas de Reciclaje",
-      "pt": null,
-      "de": "Recycling-Zellen",
-      "fr": null,
-      "ru": "Рециркуляционные ячейки",
-      "pl": null,
-      "cs": "Recycling Cells"
-    },
-    "Force Block": {
-      "es": null,
-      "pt": null,
-      "de": "Kraftsperre",
-      "fr": null,
-      "ru": "Усиленная блокировка",
-      "pl": null,
-      "cs": "Force Block"
-    },
-    "Thermo Block": {
-      "es": null,
-      "pt": null,
-      "de": "Wärmesperre",
-      "fr": null,
-      "ru": "Блокировка тепла",
-      "pl": null,
-      "cs": "Thermo Block"
-    },
-    "Blast Block": {
-      "es": null,
-      "pt": null,
-      "de": "Explosionssperre",
-      "fr": null,
-      "ru": "Блокировка взрыва",
-      "pl": null,
-      "cs": "Blast Block"
-    },
-    "Super Capacitor": {
-      "es": "Super Condensador",
-      "pt": null,
-      "de": "Superkondensatoren",
-      "fr": null,
-      "ru": "Суперконденсатор",
-      "pl": null,
-      "cs": "Super Capacitor"
-    },
-    "Hi-cap": {
-      "es": null,
-      "pt": null,
-      "de": "Hi-cap",
-      "fr": null,
-      "ru": "Высокая емкость",
-      "pl": null,
-      "cs": "Hi-cap"
-    },
-    "Multi-weave": {
-      "es": null,
-      "pt": null,
-      "de": "Mehrfachgewebe",
-      "fr": null,
-      "ru": "Мультипрошивка",
-      "pl": null,
-      "cs": "Multi-weave"
-    },
-    "Fast Charge": {
-      "es": "Carga Rápida",
-      "pt": null,
-      "de": "Schnelllader",
-      "fr": null,
-      "ru": "Быстрый заряд",
-      "pl": null,
-      "cs": "Fast Charge"
-    },
-    "Lo-draw": {
-      "es": null,
-      "pt": null,
-      "de": "Lo-draw",
-      "fr": null,
-      "ru": "Пониженное потребление",
-      "pl": null,
-      "cs": "Lo-draw"
-    },
-    "Deep Charge": {
-      "es": "Carga Profunda",
-      "pt": null,
-      "de": "Tiefenladung",
-      "fr": null,
-      "ru": "Заряд повышенной мощности",
-      "pl": null,
-      "cs": "Deep Charge"
-    },
-    "Mass Manager": {
-      "es": "Gestor de Masa",
-      "pt": null,
-      "de": "Massemanager",
-      "fr": null,
-      "ru": "Распределитель гравитации",
-      "pl": null,
-      "cs": "Mass Manager"
-    },
-    "Drive Distributors": {
-      "es": "Distribuidores de Empuje",
-      "pt": null,
-      "de": "Antriebsverteiler",
-      "fr": null,
-      "ru": "Распределители тяги",
-      "pl": null,
-      "cs": "Drive Distributors"
-    },
-    "Drag Drives": {
-      "es": "Impulsores de Arrastre",
-      "pt": null,
-      "de": "Drag Antriebe",
-      "fr": null,
-      "ru": "Ускорители",
-      "pl": null,
-      "cs": "Drag Drives"
-    },
-    "Super Conduits": {
-      "es": "Superconductores",
-      "pt": null,
-      "de": "Superleiter",
-      "fr": null,
-      "ru": "Сверхпроводники",
-      "pl": null,
-      "cs": "Super Conduits"
-    },
-    "Cluster Capacitor": {
-      "es": "Condensador de Cluster",
-      "pt": null,
-      "de": "Cluster Kondensator",
-      "fr": null,
-      "ru": "Кассетный конденсатор",
-      "pl": null,
-      "cs": "Cluster Capacitor"
-    },
-    "Thargoid": {
-      "es": "Targoide",
-      "pt": "Thargoid",
-      "de": "Thargoid",
-      "fr": null,
-      "ru": "Технологии таргоидов",
-      "pl": null,
-      "cs": "Thargoidské"
-    },
-    "Top Source Systems": {
-      "es": null,
-      "pt": null,
-      "de": "Top Quellsysteme",
-      "fr": null,
-      "ru": "Системы с обилием ресурсов",
-      "pl": null,
-      "cs": "Získáno nejvíce v systému"
-    },
-    "System:": {
-      "es": "Sistema:",
-      "pt": null,
-      "de": "System:",
-      "fr": null,
-      "ru": "Система:",
-      "pl": null,
-      "cs": "Systém:"
-    },
-    "You have:": {
-      "es": "Tienes:",
-      "pt": null,
-      "de": "Du hast:",
-      "fr": null,
-      "ru": "В наличии:",
-      "pl": null,
-      "cs": "Máš"
-    },
-    "(already needed)": {
-      "es": "(Es Necesario)",
-      "pt": null,
-      "de": "(bereits benötigt)",
-      "fr": null,
-      "ru": "(уже необходимо)",
-      "pl": null,
-      "cs": "(také potřebuješ)"
-    },
-    "Shows material trading suggestion (taking into account your cargo and the entire shopping list).": {
-      "es": "Muestra sugerencia de comercio de materiales (teniendo en cuenta tu carga y la lista de componentes completa).",
-      "pt": null,
-      "de": "Zeigt Materialhandelsvorschläge (unter Berücksichtigung Ihrer Ladung und der gesamten Einkaufsliste).",
-      "fr": null,
-      "ru": "Показывает предложения по торговле материалами (учитывая ваш груз и весь список покупок).",
-      "pl": null,
-      "cs": "Zobrazuje návrh obchodování s materiálem (s ohledem na vaše cargo a celý nákupní seznam)."
-    },
-    "Suggestions are sorted by how big the trade is compared to your cargo, minus an eventual amount already needed in the shopping list.": {
-      "es": "Las sugerencias están ordenadas por el tamaño de la transacción comparado con tu carga, menos una cantidad eventual necesaria para la lista de componentes.",
-      "pt": null,
-      "de": "Vorschläge werden nach der Größe des Handels im Vergleich zu Ihrer Ladung sortiert, abzüglich einer eventuell bereits in der Einkaufsliste benötigten Menge.",
-      "fr": null,
-      "ru": "Предложения сортируются по величине торговли по сравнению с вашим грузом, минус возможная сумма, уже необходимая в списке покупок.",
-      "pl": null,
-      "cs": "Návrhy jsou seřazeny podle toho, jak velký bude obchod v porovnání s materiály ve tvém cargu. Mínus případné položky, které jsou zapotřebí v nákupním seznamu."
-    },
-    "Orange entries indicates a trade suggestion that will not completely fulfill your requirement (but might help).": {
-      "es": "Las entradas naranjas indican una sugerencia de comercio que no completará tus requisitos (pero puede que ayude).",
-      "pt": null,
-      "de": "Orange Einträge weisen auf einen Handelsvorschlag hin, der Ihre Anforderung nicht vollständig erfüllt (aber helfen könnte).",
-      "fr": null,
-      "ru": "Оранжевые записи указывают предложения по торговле, которые не полностью отвечают требованиям (но могут помочь).",
-      "pl": null,
-      "cs": "Oranžové položky označují návrhy obchodu, které zcela nesplní tvůj požadavek, ale může ti pomoci."
-    },
-    "Materials Trader found at industrial economies, only trades in manufactured materials.": {
-      "es": "Los comerciantes de materiales encontrados en las economías industriales, solo hacen transacciones con materiales manufacturados.",
-      "pt": null,
-      "de": "Materialhändler in Industriesystemen, handeln nur mit verarbeiteten Materialien",
-      "fr": null,
-      "ru": "Торговец материалами в системах с промышленной экономикой, обменивает только промышленные материалы.",
-      "pl": null,
-      "cs": "Obchodník s materiály se může necházet v systémech s 'Industrial' ekonomikou, obchoduje pouze s vyrobenými materiály (Biotech conductors, Compound shielding atd.)."
-    },
-    "Materials Trader found at extraction and refinery economies, only trades in raw material found on planet surfaces and planetary rings.": {
-      "es": "Los comerciantes de materiales encontrados en las economías de estracción y refinería, solo hacen transacciones con materias primas encontradas en superficies de planetas y anillos planetarios.",
-      "pt": null,
-      "de": "Materialhändler, der in der Bergbau- und Raffineriewirtschaft tätig ist, handelt nur mit Rohstoffen, die auf Planetenoberflächen und Planetenringen vorkommen.",
-      "fr": null,
-      "ru": "Торговец материалами в системах с добычей ископаемых и переработкой, обменивает только сырьевые элементы.",
-      "pl": null,
-      "cs": "Obchodník s materiály se může necházet v systémech s 'Extraction' a 'Rafinery ekonomikou', obchoduje pouze se surovými materiály, které se získávají na povrchu planet a při težbě v prstencích."
-    },
-    "Materials Trader found at High Tech and Military economies, only trades in encoded materials.": {
-      "es": "Los comerciantes de materiales encontrados en las economías de alta tecnología y militares, solo hacen transacciones con materiales codificados.",
-      "pt": null,
-      "de": "Materialhändler in High-Tech- und Militär-Systemen, handeln nur mit verschlüsselten Materialien.",
-      "fr": null,
-      "ru": "Торговец материалами в системах с высокотехнологичной и военной экономикой, обменивает только зашифрованные данные.",
-      "pl": null,
-      "cs": "Obchodník s materiály se může necházet v systémech s 'High Tech' a 'Military ekonomikou', obchoduje pouze s daty."
-    },
-    "API ON": {
-      "es": "API encendida",
-      "pt": null,
-      "de": "API AN",
-      "fr": null,
-      "ru": "API ВКЛ",
-      "pl": null,
-      "cs": "API zapnuto"
-    },
-    "API OFF": {
-      "es": "API apagada",
-      "pt": null,
-      "de": "API AUS",
-      "fr": null,
-      "ru": "API ВЫКЛ",
-      "pl": null,
-      "cs": "API vypnuto"
-    },
-    "Long Range FSD Interdictor": {
-      "es": null,
-      "pt": null,
-      "de": null,
-      "fr": null,
-      "ru": "FSD-перехватчик большой дальности",
-      "pl": null,
-      "cs": "Long Range FSD Interdictor"
-    },
-    "Guardian Plasma Charger Munitions": {
-      "es": "Munición de Cargador de Plasma Guardián",
-      "pt": null,
-      "de": "Guardian-Plasmaladermunition",
-      "fr": null,
-      "ru": "Боеприпасы для плазменных пушек стражей",
-      "pl": null,
-      "cs": "Munice do Guardian Plasma Charger"
-    },
-    "Guardian Gauss Cannon Munitions": {
-      "es": "Munición de Cañón Gauss Guardián",
-      "pt": null,
-      "de": "Guardian-Gausskannonenmunition",
-      "fr": null,
-      "ru": "Боеприпасы для пушек Гаусса стражей",
-      "pl": null,
-      "cs": "Munice do Guardian Gauss Cannon"
-    },
-    "AX Small Calibre Munitions": {
-      "es": "Munición AX de calibre pequeño",
-      "pt": null,
-      "de": "Kleinkalibrige Munition (AX)",
-      "fr": null,
-      "ru": "Мелкокалиберные боеприпасы АИ",
-      "pl": null,
-      "cs": "Munice malé ráže do AX zbraní (AX MC)"
-    },
-    "+5% Damage Boost": {
-      "es": "Aumento de Daño +5%",
-      "pt": null,
-      "de": "Bonus Schaden: +5%",
-      "fr": null,
-      "ru": "+5% к урону",
-      "pl": null,
-      "cs": "+5% boost k poškození"
-    },
-    "+10% Damage Boost": {
-      "es": "Aumento de Daño +10%",
-      "pt": null,
-      "de": "Bonus Schaden: +10%",
-      "fr": null,
-      "ru": "+10% к урону",
-      "pl": null,
-      "cs": "+10% boost k poškození"
-    },
-    "AX Remote Flak Munitions": {
-      "es": null,
-      "pt": null,
-      "de": "Munition für Ferngezündete Flak (AX)",
-      "fr": null,
-      "ru": "Зенитные снаряды с дистанционным подрывом АИ",
-      "pl": null,
-      "cs": "Munice do AX Remote Flaku"
-    },
-    "Enzyme Missile Launcher Munitions": {
-      "es": null,
-      "pt": null,
-      "de": "Enzymraketenwerfermunition",
-      "fr": null,
-      "ru": "Боеприпасы для энзимных ракетных установок",
-      "pl": null,
-      "cs": "Munice do Enzyme Missile Launcher"
-    },
-    "Flechette Launcher Munitions": {
-      "es": null,
-      "pt": null,
-      "de": "Flechettewerfermunition",
-      "fr": null,
-      "ru": "Стреловидные боеприпасы",
-      "pl": null,
-      "cs": "Munice do Flechette Launcher"
-    },
-    "Guardian Shard Cannon Munitions": {
-      "es": null,
-      "pt": null,
-      "de": "Guardian-Fragmentkanonenmunition",
-      "fr": null,
-      "ru": "Боеприпасы для осколочных орудий стражей",
-      "pl": null,
-      "cs": "Munice do Guardian Shard Cannon"
-    },
-    "AX Explosive Munitions": {
-      "es": null,
-      "pt": null,
-      "de": "Explosivmunition (AX)",
-      "fr": null,
-      "ru": "Взрывчатые боеприпасы АИ",
-      "pl": null,
-      "cs": "Explozivní munice do AX zbraní (rakety)"
-    },
-    "+5% Damage": {
-      "es": "+5% Daño",
-      "pt": null,
-      "de": "Bonus Schaden: +5%",
-      "fr": null,
-      "ru": "+5% к урону",
-      "pl": null,
-      "cs": "+5% poškození"
-    },
-    "Guardian Gauss Cannon (Fixed, Medium)": {
-      "es": null,
-      "pt": null,
-      "de": "Guardian-Gausskanone (Fest) (Klasse: 2)",
-      "fr": null,
-      "ru": "Пушка Гаусса стражей (фиксированное, средний слот)",
-      "pl": null,
-      "cs": "Guardian Gauss Cannon (Fixed, Medium)"
-    },
-    "Guardian Gauss Cannon (Fixed, Small)": {
-      "es": null,
-      "pt": null,
-      "de": "Guardian-Gausskanone (Fest) (Klasse: 1)",
-      "fr": null,
-      "ru": "Пушка Гаусса стражей (фиксированное, малый слот)",
-      "pl": null,
-      "cs": "Guardian Gauss Cannon (Fixed, Small)"
-    },
-    "Guardian Hull Reinforcement": {
-      "es": null,
-      "pt": null,
-      "de": "Guardian-Rumpfhüllenverstärkung",
-      "fr": null,
-      "ru": "Набор для усиления корпуса стражей",
-      "pl": null,
-      "cs": "Guardian Hull Reinforcement"
-    },
-    "Guardian Module Reinforcement": {
-      "es": null,
-      "pt": null,
-      "de": "Guardian-Modulverstärkung",
-      "fr": null,
-      "ru": "Набор для усиления модуля стражей",
-      "pl": null,
-      "cs": "Guardian Module Reinforcement"
-    },
-    "Guardian Plasma Charger (Fixed, Large)": {
-      "es": null,
-      "pt": null,
-      "de": "Guardian-Plasmalader (Fest) (Klasse: 3)",
-      "fr": null,
-      "ru": "Плазменная пушка стражей (фиксированное, большой слот)",
-      "pl": null,
-      "cs": "Guardian Plasma Charger (Fixed, Large)"
-    },
-    "Guardian Plasma Charger (Fixed, Medium)": {
-      "es": null,
-      "pt": null,
-      "de": "Guardian-Plasmalader (Fest) (Klasse: 2)",
-      "fr": null,
-      "ru": "Плазменная пушка стражей (фиксированное, средний слот)",
-      "pl": null,
-      "cs": "Guardian Plasma Charger (Fixed, Medium)"
-    },
-    "Guardian Plasma Charger (Fixed, Small)": {
-      "es": null,
-      "pt": null,
-      "de": "Guardian-Plasmalader (Fest) (Klasse: 1)",
-      "fr": null,
-      "ru": "Плазменная пушка стражей (фиксированное, малый слот)",
-      "pl": null,
-      "cs": "Guardian Plasma Charger (Fixed, Small)"
-    },
-    "Guardian Plasma Charger (Turreted, Large)": {
-      "es": null,
-      "pt": null,
-      "de": "Guardian-Plasmalader (Turm) (Klasse: 3)",
-      "fr": null,
-      "ru": "Плазменная пушка стражей (турель, большой слот)",
-      "pl": null,
-      "cs": "Guardian Plasma Charger (Turreted, Large)"
-    },
-    "Guardian Plasma Charger (Turreted, Medium)": {
-      "es": null,
-      "pt": null,
-      "de": "Guardian-Plasmalader (Turm) (Klasse: 2)",
-      "fr": null,
-      "ru": "Плазменная пушка стражей (турель, средний слот)",
-      "pl": null,
-      "cs": "Guardian Plasma Charger (Turreted, Medium)"
-    },
-    "Guardian Plasma Charger (Turreted, Small)": {
-      "es": null,
-      "pt": null,
-      "de": "Guardian-Plasmalader (Turm) (Klasse: 1)",
-      "fr": null,
-      "ru": "Плазменная пушка стражей (турель, малый слот)",
-      "pl": null,
-      "cs": "Guardian Plasma Charger (Turreted, Small)"
-    },
-    "Guardian FSD Booster": {
-      "es": null,
-      "pt": null,
-      "de": "Guardian-Frameshiftantrieb-Booster",
-      "fr": null,
-      "ru": "Ускоритель FSD стражей",
-      "pl": null,
-      "cs": "Guardian FSD Booster"
-    },
-    "Guardian Power Distributor": {
-      "es": null,
-      "pt": null,
-      "de": "Guardian-Energieverteiler",
-      "fr": null,
-      "ru": "Распределитель питания стражей",
-      "pl": null,
-      "cs": "Guardian Power Distributor"
-    },
-    "Guardian Shard Cannon (Fixed, Large)": {
-      "es": null,
-      "pt": null,
-      "de": "Guardian-Fragmentkanone (Fest) (Klasse: 3)",
-      "fr": null,
-      "ru": "Осколочное орудие стражей (фиксированное, большой слот)",
-      "pl": null,
-      "cs": "Guardian Shard Cannon (Fixed, Large)"
-    },
-    "Guardian Shard Cannon (Fixed, Medium)": {
-      "es": null,
-      "pt": null,
-      "de": "Guardian-Fragmentkanone (Fest) (Klasse: 2)",
-      "fr": null,
-      "ru": "Осколочное орудие стражей (фиксированное, средний слот)",
-      "pl": null,
-      "cs": "Guardian Shard Cannon (Fixed, Medium)"
-    },
-    "Guardian Shard Cannon (Fixed, Small)": {
-      "es": null,
-      "pt": null,
-      "de": "Guardian-Fragmentkanone (Fest) (Klasse: 1)",
-      "fr": null,
-      "ru": "Осколочное орудие стражей (фиксированное, малый слот)",
-      "pl": null,
-      "cs": "Guardian Shard Cannon (Fixed, Small)"
-    },
-    "Guardian Shard Cannon (Turreted, Large)": {
-      "es": null,
-      "pt": null,
-      "de": "Guardian-Fragmentkanone (Turm) (Klasse: 3)",
-      "fr": null,
-      "ru": "Осколочное орудие стражей (турель, большой слот)",
-      "pl": null,
-      "cs": "Guardian Shard Cannon (Turreted, Large)"
-    },
-    "Guardian Shard Cannon (Turreted, Medium)": {
-      "es": null,
-      "pt": null,
-      "de": "Guardian-Fragmentkanone (Turm) (Klasse: 2)",
-      "fr": null,
-      "ru": "Осколочное орудие стражей (турель, средний слот)",
-      "pl": null,
-      "cs": "Guardian Shard Cannon (Turreted, Medium)"
-    },
-    "Guardian Shard Cannon (Turreted, Small)": {
-      "es": null,
-      "pt": null,
-      "de": "Guardian-Fragmentkanone (Turm) (Klasse: 1)",
-      "fr": null,
-      "ru": "Осколочное орудие стражей (турель, малый слот)",
-      "pl": null,
-      "cs": "Guardian Shard Cannon (Turreted, Small)"
-    },
-    "Guardian Shield Reinforcement": {
-      "es": null,
-      "pt": null,
-      "de": "Guardian-Schildverstärkung",
-      "fr": null,
-      "ru": "Набор для усиления щита стражей",
-      "pl": null,
-      "cs": "Guardian Shield Reinforcement"
-    },
-    "Javelin (Fighter)": {
-      "es": null,
-      "pt": null,
-      "de": "Javelin (Fighter)",
-      "fr": null,
-      "ru": "Javelin (Истребитель)",
-      "pl": null,
-      "cs": "Javelin (Fighter)"
-    },
-    "Lance (Fighter)": {
-      "es": null,
-      "pt": null,
-      "de": "Lance (Fighter)",
-      "fr": null,
-      "ru": "Lance (Истребитель)",
-      "pl": null,
-      "cs": "Lance (Fighter)"
-    },
-    "Trident (Fighter)": {
-      "es": null,
-      "pt": null,
-      "de": "Trident (Fighter)",
-      "fr": null,
-      "ru": "Trident (Истребитель)",
-      "pl": null,
-      "cs": "Trident (Fighter)"
-    },
-    "Shock Cannon (Fixed, Large)": {
-      "es": null,
-      "pt": null,
-      "de": null,
-      "fr": null,
-      "ru": "Осколочное орудие стражей (фиксированное, большой слот)",
-      "pl": null,
-      "cs": "Shock Cannon (Fixed, Large)"
-    },
-    "Shock Cannon (Fixed, Medium)": {
-      "es": null,
-      "pt": null,
-      "de": null,
-      "fr": null,
-      "ru": "Шоковое орудие (фиксированное, средний слот)",
-      "pl": null,
-      "cs": "Shock Cannon (Fixed, Medium)"
-    },
-    "Shock Cannon (Fixed, Small)": {
-      "es": null,
-      "pt": null,
-      "de": null,
-      "fr": null,
-      "ru": "Шоковое орудие (фиксированное, малый слот)",
-      "pl": null,
-      "cs": "Shock Cannon (Fixed, Small)"
-    },
-    "Shock Cannon (Gimballed, Large)": {
-      "es": null,
-      "pt": null,
-      "de": null,
-      "fr": null,
-      "ru": "Шоковое орудие (на карданной подвеске, большой слот)",
-      "pl": null,
-      "cs": "Shock Cannon (Gimballed, Large)"
-    },
-    "Shock Cannon (Gimballed, Medium)": {
-      "es": null,
-      "pt": null,
-      "de": null,
-      "fr": null,
-      "ru": "Шоковое орудие (на карданной подвеске, средний слот)",
-      "pl": null,
-      "cs": "Shock Cannon (Gimballed, Medium)"
-    },
-    "Shock Cannon (Gimballed, Small)": {
-      "es": null,
-      "pt": null,
-      "de": null,
-      "fr": null,
-      "ru": "Шоковое орудие (на карданной подвеске, малый слот)",
-      "pl": null,
-      "cs": "Shock Cannon (Gimballed, Small)"
-    },
-    "Shock Cannon (Turreted, Large)": {
-      "es": null,
-      "pt": null,
-      "de": null,
-      "fr": null,
-      "ru": "Шоковое орудие (турель, большой слот)",
-      "pl": null,
-      "cs": "Shock Cannon (Turreted, Large)"
-    },
-    "Shock Cannon (Turreted, Medium)": {
-      "es": null,
-      "pt": null,
-      "de": null,
-      "fr": null,
-      "ru": "Шоковое орудие (турель, средний слот)",
-      "pl": null,
-      "cs": "Shock Cannon (Turreted, Medium)"
-    },
-    "Shock Cannon (Turreted, Small)": {
-      "es": null,
-      "pt": null,
-      "de": null,
-      "fr": null,
-      "ru": "Шоковое орудие (турель, малый слот)",
-      "pl": null,
-      "cs": "Shock Cannon (Turreted, Small)"
-    },
-    "Ship Value:": {
-      "es": null,
-      "pt": null,
-      "de": "Wert dieses Shiffs",
-      "fr": null,
-      "ru": "Стоимость корабля:",
-      "pl": null,
-      "cs": "Cena lodi:"
-    },
-    "Modules Value:": {
-      "es": null,
-      "pt": null,
-      "de": "Wert der Module",
-      "fr": null,
-      "ru": "Стоимость модулей:",
-      "pl": null,
-      "cs": "Cena modulů:"
-    },
-    "Rebuy:": {
-      "es": null,
-      "pt": null,
-      "de": "Ersatzwert",
-      "fr": null,
-      "ru": "Страховка:",
-      "pl": null,
-      "cs": "Rebuy:"
-    },
-    "Loadout": {
-      "es": null,
-      "pt": null,
-      "de": "Ausrüstung",
-      "fr": null,
-      "ru": "Оснащение",
-      "pl": null,
-      "cs": "Výzbroj"
-    },
-    "Cargo History (require API)": {
-      "es": null,
-      "pt": null,
-      "de": "Fracht Historie (Benötigt API)",
-      "fr": null,
-      "ru": "История грузов (необходимо API)",
-      "pl": null,
-      "cs": "Historie nákladu (vyžaduje API)"
-    },
-    "Hardpoints": {
-      "es": null,
-      "pt": null,
-      "de": "Aufhängungen",
-      "fr": null,
-      "ru": "Орудийные гнезда",
-      "pl": null,
-      "cs": "Hardpoints"
-    },
-    "Utilities": {
-      "es": null,
-      "pt": null,
-      "de": "Werkzeuge",
-      "fr": null,
-      "ru": "Крепления утилит",
-      "pl": null,
-      "cs": "Utilities"
-    },
-    "Core Internal": {
-      "es": null,
-      "pt": null,
-      "de": "Intern (Basis)",
-      "fr": null,
-      "ru": "Зарезервированные слоты",
-      "pl": null,
-      "cs": "Core Internal"
-    },
-    "Optional Internal": {
-      "es": null,
-      "pt": null,
-      "de": "Intern (Optional)",
-      "fr": null,
-      "ru": "Опциональные модули",
-      "pl": null,
-      "cs": "Optional Internal"
-    },
-    "Others/Livery": {
-      "es": null,
-      "pt": null,
-      "de": "Diverses/Lackierung",
-      "fr": null,
-      "ru": "Прочее/Декали",
-      "pl": null,
-      "cs": "Ostatní/Livery"
-    },
-    "Occupied Escape Pod": {
-      "es": null,
-      "pt": null,
-      "de": "Besetzte Rettungskapsel",
-      "fr": null,
-      "ru": "Спасательная капсула с пассажиром",
-      "pl": null,
-      "cs": "Occupied Escape Pod"
-    },
-    "Progenitor Cells": {
-      "es": null,
-      "pt": null,
-      "de": "Vorläuferzellen",
-      "fr": null,
-      "ru": "Прогениторные клетки",
-      "pl": null,
-      "cs": "Progenitor Cells"
-    },
-    "Sync?": {
-      "es": null,
-      "pt": null,
-      "de": "Synchronisieren?",
-      "fr": null,
-      "ru": "Синхронизировать?",
-      "pl": null,
-      "cs": "Synchronizovat?"
-    },
-    "Guardian Wreckage Components": {
-      "es": null,
-      "pt": null,
-      "de": "Guardian-Wrackteilkomponenten",
-      "fr": null,
-      "ru": "Обломки часовых стражей",
-      "pl": null,
-      "cs": "Guardian Wreckage Components"
-    },
-    "Reload all data": {
-      "es": null,
-      "pt": null,
-      "de": null,
-      "fr": null,
-      "ru": null,
-      "pl": null,
-      "cs": "Znovu načíst všechna data"
-    }
-  }
+		},
+		"Cannon": {
+			"es": "Cañón",
+			"pt": "Canhão",
+			"de": "Kanone",
+			"fr": "Canon",
+			"ru": "Орудие",
+			"pl": "Cannon",
+			"cs": "Cannon"
+		},
+		"Thrusters": {
+			"es": "Impulsores",
+			"pt": "Propulsores",
+			"de": "Schubdüsen",
+			"fr": "Moteurs",
+			"ru": "Маневровые двигатели",
+			"pl": "Thrusters",
+			"cs": "Thrusters"
+		},
+		"Multi-cannon": {
+			"es": "Multicañón",
+			"pt": "Canhão de Repetição",
+			"de": "Mehrfachgeschütz",
+			"fr": "Multi-cannon",
+			"ru": "Многоствольное орудие",
+			"pl": "Multi-cannon",
+			"cs": "Multi-cannon"
+		},
+		"Missile Rack": {
+			"es": "Batería de Misiles",
+			"pt": "Estante de Mísseis",
+			"de": "Raketenrampe",
+			"fr": "Rack de Missiles",
+			"ru": "Ракетный лоток",
+			"pl": "Missile Rack",
+			"cs": "Missile Rack"
+		},
+		"Power Plant": {
+			"es": "Núcleo de Energía",
+			"pt": "Gerador de Energia",
+			"de": "Kraftwerk",
+			"fr": "Générateur",
+			"ru": "Силовая установка",
+			"pl": "Power Plant",
+			"cs": "Power Plant"
+		},
+		"Chaff Launcher": {
+			"es": "Lanzador de Señuelos",
+			"pt": "Lançador de Chaff",
+			"de": "Düppel-Werfer",
+			"fr": "Contre-Mesures",
+			"ru": "Разбрасыватель дип. отражателей",
+			"pl": "Chaff Launcher",
+			"cs": "Chaff Launcher"
+		},
+		"Frame Shift Drive Interdictor": {
+			"es": "Interdictor de MDD",
+			"pt": "Interditor de Motor de Distorção",
+			"de": "FSA-Unterbrecher",
+			"fr": "Interdicteur FSD",
+			"ru": "FSD перехватчик",
+			"pl": "Frame Shift Drive Interdictor",
+			"cs": "Frame Shift Drive Interdictor"
+		},
+		"Shield Generator": {
+			"es": "Generador de Escudos",
+			"pt": "Gerador de Escudo",
+			"de": "Schildgenerator",
+			"fr": "Générateur de Bouclier",
+			"ru": "Щитогенератор",
+			"pl": "Shield Generator",
+			"cs": "Shield Generator"
+		},
+		"Point Defence": {
+			"es": "Defensa de Punto",
+			"pt": "Defesa de Ponto",
+			"de": "Punktverteidigung",
+			"fr": "Défense ponctuelle",
+			"ru": "Точечная оборона",
+			"pl": "Point Defence",
+			"cs": "Point Defence"
+		},
+		"Shield Booster": {
+			"es": "Potenciador de Escudos",
+			"pt": "Potenciador de Escudo",
+			"de": "Schild-Booster",
+			"fr": "Survolteur de Bouclier",
+			"ru": "Усилитель щита",
+			"pl": "Shield Booster",
+			"cs": "Shield Booster"
+		},
+		"Kill Warrant Scanner": {
+			"es": "Escáner de Registro Criminal",
+			"pt": "Scanner de Registro Criminal",
+			"de": "Tötungsbefehl-Scanner",
+			"fr": "Scanner d'avis de recherches",
+			"ru": "Сканер преступников",
+			"pl": "Kill Warrant Scanner",
+			"cs": "Kill Warrant Scanner"
+		},
+		"Rail Gun": {
+			"es": "Cañón de Riel",
+			"pt": "Canhão Elétrico",
+			"de": "Schienenkanone",
+			"fr": "Canon électrique",
+			"ru": "Электромагнитная пушка",
+			"pl": "Rail Gun",
+			"cs": "Rail Gun"
+		},
+		"Power Distributor": {
+			"es": "Distribuidor de Energía",
+			"pt": "Distribuidor de Energia",
+			"de": "Energieverteiler",
+			"fr": "Répartiteur de Puissance",
+			"ru": "Распределитель питания",
+			"pl": "Power Distributor",
+			"cs": "Power Distributor"
+		},
+		"Fragment Cannon": {
+			"es": "Cañón de Fragmentación",
+			"pt": "Canhão de Fragmentos",
+			"de": "Splitterkanone",
+			"fr": "Canon à fragmentation",
+			"ru": "Залповое орудие",
+			"pl": "Fragment Cannon",
+			"cs": "Fragment Cannon"
+		},
+		"Mine Launcher": {
+			"es": "Lanzaminas",
+			"pt": "Lança Minas",
+			"de": "Minenwerfer",
+			"fr": "Lanceur de mines",
+			"ru": "Минирующее устройство",
+			"pl": "Mine Launcher",
+			"cs": "Mine Launcher"
+		},
+		"Beam Laser": {
+			"es": "Láser de Rayo",
+			"pt": "Laser Contínuo",
+			"de": "Strahlenlaser",
+			"fr": "Rayon Laser",
+			"ru": "Пучковый лазер",
+			"pl": "Beam Laser",
+			"cs": "Beam Laser"
+		},
+		"Armour": {
+			"es": "Blindaje",
+			"pt": "Blindagem",
+			"de": "Panzerung",
+			"fr": "Armure",
+			"ru": "Броня",
+			"pl": "Armour",
+			"cs": "Armour"
+		},
+		"Prospector Limpet Controller": {
+			"es": "Lanzador Dron Prospector",
+			"pt": "Controlador de Drone Prospector",
+			"de": "Drohnensteuerung Erzsucher",
+			"fr": "Controleur de drônes de prospection",
+			"ru": "Контроллер дронов геологов",
+			"pl": "Prospector Limpet Controller",
+			"cs": "Prospector Limpet Controller"
+		},
+		"Manifest Scanner": {
+			"es": "Escáner de Carga",
+			"pt": "Scanner de Manifesto",
+			"de": "Verzeichnisscanner",
+			"fr": "Scanner de soute",
+			"ru": "Сканер накладной",
+			"pl": "Manifest Scanner",
+			"cs": "Manifest Scanner"
+		},
+		"Burst Laser": {
+			"es": "Láser de Ráfagas",
+			"pt": "Laser de Rajada",
+			"de": "Salvenlaser",
+			"fr": "Laser à Rafale",
+			"ru": "Пульсирующий лазер",
+			"pl": "Burst Laser",
+			"cs": "Burst Laser"
+		},
+		"Heat Sink Launcher": {
+			"es": "Eyector Térmico",
+			"pt": "Lançador de Dissipador Térmico",
+			"de": "Kühlkörperwerfer",
+			"fr": "Dissipateur thermique",
+			"ru": "Теплоотводная катапульта",
+			"pl": "Heat Sink Launcher",
+			"cs": "Heat Sink Launcher"
+		},
+		"Pulse Laser": {
+			"es": "Láser de Pulso",
+			"pt": "Laser de Pulso",
+			"de": "Impulslaser",
+			"fr": "Laser à Impulsion",
+			"ru": "Импульсный лазер",
+			"pl": "Pulse Laser",
+			"cs": "Pulse Laser"
+		},
+		"Refinery": {
+			"es": "Refinería",
+			"pt": "Refinaria",
+			"de": "Raffinerie",
+			"fr": "Raffinerie",
+			"ru": "Очиститель",
+			"pl": "Refinery",
+			"cs": "Refinery"
+		},
+		"Auto Field-Maintenance Unit": {
+			"es": "Unidad de Automantenimiento",
+			"pt": "Unidade de Manutenção",
+			"de": "Automatische Feldwartungs-Einheit",
+			"fr": "MTA",
+			"ru": "Блок автоматического полевого ремонта",
+			"pl": "Auto Field-Maintenance Unit",
+			"cs": "Auto Field-Maintenance Unit"
+		},
+		"Fuel Transfer Limpet Controller": {
+			"es": "Lanzador Dron Combustible",
+			"pt": "Controlador de Drone Transferidor de Combustível",
+			"de": "Treibstofftransfer-Drohnensteuerung",
+			"fr": "Contrôleur de drone de ravitaillement",
+			"ru": "Контроллер дронов заправщиков",
+			"pl": "Fuel Transfer Limpet Controller",
+			"cs": "Fuel Transfer Limpet Controller"
+		},
+		"Frame Shift Drive": {
+			"es": "Motor de Distorsión",
+			"pt": "Motor de Distorção de Fase",
+			"de": "Frameshiftantrieb",
+			"fr": "FSD",
+			"ru": "FSD",
+			"pl": "Frame Shift Drive",
+			"cs": "Frame Shift Drive"
+		},
+		"Hatch Breaker Limpet Controller": {
+			"es": "Lanzador Dron Extractor",
+			"pt": "Controlador de Drone Quebra-Escotilha",
+			"de": "Steuereinheit Ladelukenöffner-Drohne",
+			"fr": "Perce-Soute",
+			"ru": "Контроллер дронов взломщиков",
+			"pl": "Hatch Breaker Limpet Controller",
+			"cs": "Hatch Breaker Limpet Controller"
+		},
+		"Fuel Scoop": {
+			"es": "Colector de Combustible",
+			"pt": "Coletor de Combustível",
+			"de": "Treibstoffsammler",
+			"fr": "Récupérateur de carburant",
+			"ru": "Топливозаборник",
+			"pl": "Fuel Scoop",
+			"cs": "Fuel Scoop"
+		},
+		"Torpedo Pylon": {
+			"es": "Lanzatorpedos",
+			"pt": "Pilone de Torpedo",
+			"de": "Torpedopylon",
+			"fr": "Torpilles",
+			"ru": "Торпедная стойка",
+			"pl": "Torpedo Pylon",
+			"cs": "Torpedo Pylon"
+		},
+		"Collector Limpet Controller": {
+			"es": "Lanzador Dron Colector",
+			"pt": "Controlador de Drone Coletor",
+			"de": "Steuerung Sammeldrohne",
+			"fr": "Controleur de drône collecteur",
+			"ru": "Контроллер дронов сборщиков",
+			"pl": "Collector Limpet Controller",
+			"cs": "Collector Limpet Controller"
+		},
+		"Shield Cell Bank": {
+			"es": "Células de Escudo",
+			"pt": "Banco de Célula de Escudo",
+			"de": "Schildzellenbank",
+			"fr": "Cellules d'énergie",
+			"ru": "Щитонакопитель",
+			"pl": "Shield Cell Bank",
+			"cs": "Shield Cell Bank"
+		},
+		"Aberrant Shield Pattern Analysis": {
+			"es": "Análisis de Patrón de Escudo Aberrantes",
+			"pt": "Análise de padrão de escudos Aberrante",
+			"de": "Abweichende Schildeinsatz-Analysen",
+			"fr": "Analyse de modèle de bouclier aberrante",
+			"ru": "Анализ аномального поведения щита",
+			"pl": "Aberrant Shield Pattern Analysis",
+			"cs": "Aberrant Shield Pattern Analysis"
+		},
+		"Abnormal Compact Emission Data": {
+			"es": "Compresión de Datos de Transmisiones Anormal",
+			"pt": "Dados de Emissão Compáctos Anormais",
+			"de": "Anormale Kompakte Emissionsdaten",
+			"fr": "Données d'émissions compactes anormales",
+			"ru": "Аномальные компактные данные об излучении",
+			"pl": "Abnormal Compact Emission Data",
+			"cs": "Abnormal Compact Emission Data"
+		},
+		"Adaptive Encryptors Capture": {
+			"es": "Captura de Encriptadores Adaptativos",
+			"pt": "Encriptadores Adaptativos Capturados",
+			"de": "Adaptive Verschlüsselungserfassung",
+			"fr": "Capture de cryptage évolutif",
+			"ru": "Захват адаптивного шифровальщика",
+			"pl": "Adaptive Encryptors Capture",
+			"cs": "Adaptive Encryptors Capture"
+		},
+		"Anomalous Bulk Scan Data": {
+			"es": "Datos de Escáner en Bruto Anómalos",
+			"pt": "Dados Brutos de Escâner Anômalos",
+			"de": "Anormale Massen-Scan-Daten",
+			"fr": "Fichier volumineux d'analyse anormal",
+			"ru": "Аномальный массив данных сканирования",
+			"pl": "Anomalous Bulk Scan Data",
+			"cs": "Anomalous Bulk Scan Data"
+		},
+		"Anomalous FSD Telemetry": {
+			"es": "Telemetría de MDD Anómala",
+			"pt": "Telemetria Anômala de MDD",
+			"de": "Anormale FSA-Telemetrie",
+			"fr": "Télémétrie FSD anormale",
+			"ru": "Аномальная телеметрия FSD",
+			"pl": "Anomalous FSD Telemetry",
+			"cs": "Anomalous FSD Telemetry"
+		},
+		"Antimony": {
+			"es": "Antimonio",
+			"pt": "Antimônio",
+			"de": "Antimon",
+			"fr": "Antimoine",
+			"ru": "Сурьма",
+			"pl": "Antimony",
+			"cs": "Antimony"
+		},
+		"Arsenic": {
+			"es": "Arsénico",
+			"pt": "Arsênico",
+			"de": "Arsen",
+			"fr": "Arsenic",
+			"ru": "Мышьяк",
+			"pl": "Arsenic",
+			"cs": "Arsenic"
+		},
+		"Articulation Motors": {
+			"es": "Motores de Articulación",
+			"pt": "Motores de articulações",
+			"de": "Gelenkmotoren",
+			"fr": "Moteur à articulation",
+			"ru": "Шарнирные моторы",
+			"pl": "Articulation Motors",
+			"cs": "Articulation Motors"
+		},
+		"Atypical Disrupted Wake Echoes": {
+			"es": "Ecos de Estelas Interrumpidas Atípicos",
+			"pt": "Interferência Atípica no Eco de Rastros",
+			"de": "Atypische FSA-Stör-Aufzeichnungen",
+			"fr": "Echos de sillages perturbés atypiques",
+			"ru": "Атипичное эхо поврежденного следа",
+			"pl": "Atypical Disrupted Wake Echoes",
+			"cs": "Atypical Disrupted Wake Echoes"
+		},
+		"Atypical Encryption Archives": {
+			"es": "Archivos Encriptados Atípicos",
+			"pt": "Arquivos De Encriptação Atípicos",
+			"de": "Atypische Verschlüsselungsarchive",
+			"fr": "Archives cryptées atypiques",
+			"ru": "Нетипичные архивы шифрования",
+			"pl": "Atypical Encryption Archives",
+			"cs": "Atypical Encryption Archives"
+		},
+		"Basic Conductors": {
+			"es": "Conductores Básicos",
+			"pt": "Condutores básicos",
+			"de": "Einfache Leiter",
+			"fr": "conducteurs simples",
+			"ru": "Простые проводники",
+			"pl": "Basic Conductors",
+			"cs": "Basic Conductors"
+		},
+		"Biotech Conductors": {
+			"es": "Conductores Biotecnológicos",
+			"pt": "Condutores biotecnológicos",
+			"de": "Biotech-Leiter",
+			"fr": "Conducteurs biotechniques",
+			"ru": "Биотехнические проводники",
+			"pl": "Biotech Conductors",
+			"cs": "Biotech Conductors"
+		},
+		"Bromellite": {
+			"es": "Bromelita",
+			"pt": "Bromelito",
+			"de": "Bromellit",
+			"fr": "Bromellite",
+			"ru": "Бромеллит",
+			"pl": "Bromellite",
+			"cs": "Bromellite"
+		},
+		"Cadmium": {
+			"es": "Cadmio",
+			"pt": "Cádmio",
+			"de": "Kadmium",
+			"fr": "Cadmium",
+			"ru": "Кадмий",
+			"pl": "Cadmium",
+			"cs": "Cadmium"
+		},
+		"Carbon": {
+			"es": "Carbono",
+			"pt": "Carbono",
+			"de": "Kohlenstoff",
+			"fr": "Carbone",
+			"ru": "Углерод",
+			"pl": "Carbon",
+			"cs": "Carbon"
+		},
+		"Chemical Distillery": {
+			"es": "Destilería Química",
+			"pt": "Destilaria química",
+			"de": "Chemiedestillerie",
+			"fr": "Distilerie chimique",
+			"ru": "Оборудование для перегонки химикатов",
+			"pl": "Chemical Distillery",
+			"cs": "Chemical Distillery"
+		},
+		"Chemical Manipulators": {
+			"es": "Manipuladores Químicos",
+			"pt": "Manipuladores químicos",
+			"de": "Chemische Manipulatoren",
+			"fr": "Manipulateurs chimiques",
+			"ru": "Манипуляторы для работы с химикатами",
+			"pl": "Chemical Manipulators",
+			"cs": "Chemical Manipulators"
+		},
+		"Chemical Processors": {
+			"es": "Procesadores Químicos",
+			"pt": "Processadores químicos",
+			"de": "Chemische Prozessoren",
+			"fr": "Processeurs chimiques",
+			"ru": "Оборудование для химобработки",
+			"pl": "Chemical Processors",
+			"cs": "Chemical Processors"
+		},
+		"Chemical Storage Units": {
+			"es": "Unidades de Almacenamiento Químico",
+			"pt": "Unidades de armazenamento químico",
+			"de": "Chemische Lagereinheiten",
+			"fr": "Unités de stockage chimique",
+			"ru": "Контейнеры для химикатов",
+			"pl": "Chemical Storage Units",
+			"cs": "Chemical Storage Units"
+		},
+		"Chromium": {
+			"es": "Cromo",
+			"pt": "Cromo",
+			"de": "Chrom",
+			"fr": "Chrome",
+			"ru": "Хром",
+			"pl": "Chromium",
+			"cs": "Chromium"
+		},
+		"Classified Scan Databanks": {
+			"es": "Datos de Escáner Clasificados",
+			"pt": "Banco de Dados de Escaneamento Confidenciais",
+			"de": "Scan-Datenbanken unter Verschluss",
+			"fr": "Banques de données d'analyse classifiées",
+			"ru": "Засекреченные базы данных сканирования",
+			"pl": "Classified Scan Databanks",
+			"cs": "Classified Scan Databanks"
+		},
+		"Classified Scan Fragment": {
+			"es": "Fragmento de Escáner Clasificado",
+			"pt": "Fragmento de Escaneamento Confidenciais",
+			"de": "Geheimes Scan Fragment",
+			"fr": "Données d'analyse classifiées parcellaires",
+			"ru": "Засекреченные фрагменты данных сканирования",
+			"pl": "Classified Scan Fragment",
+			"cs": "Classified Scan Fragment"
+		},
+		"CMM Composite": {
+			"es": "Compuesto CMM",
+			"pt": "Compostos CMM",
+			"de": "CMM-Komposit",
+			"fr": "composite MMC",
+			"ru": "CMM-композит",
+			"pl": "CMM Composite",
+			"cs": "CMM Composite"
+		},
+		"Compact Composites": {
+			"es": "Compuestos Compactos",
+			"pt": "Compostos compactos",
+			"de": "Kompakt-Komposit",
+			"fr": "Composites compacts",
+			"ru": "Спрессованные композиты",
+			"pl": "Compact Composites",
+			"cs": "Compact Composites"
+		},
+		"Compound Shielding": {
+			"es": "Escudos Compuestos",
+			"pt": "Proteção Composta",
+			"de": "Verbundschilde",
+			"fr": "Protection Composite",
+			"ru": "Многоступенчатая защита",
+			"pl": "Compound Shielding",
+			"cs": "Compound Shielding"
+		},
+		"Conductive Ceramics": {
+			"es": "Cerámicas Conductivas",
+			"pt": "Condutoras Cerâmicas",
+			"de": "Elektrokeramiken",
+			"fr": "Conducteurs en céramique",
+			"ru": "Проводящая керамика",
+			"pl": "Conductive Ceramics",
+			"cs": "Conductive Ceramics"
+		},
+		"Conductive Components": {
+			"es": "Componentes Conductivos",
+			"pt": "Componentes Condutores",
+			"de": "Leitfähige Komponenten",
+			"fr": "Composants conducteurs",
+			"ru": "Проводящие компоненты",
+			"pl": "Conductive Components",
+			"cs": "Conductive Components"
+		},
+		"Conductive Polymers": {
+			"es": "Polímeros Conductivos",
+			"pt": "Polímeros Condutores",
+			"de": "Leitfähige Polymere",
+			"fr": "Conducteurs en polymères",
+			"ru": "Проводящие полимеры",
+			"pl": "Conductive Polymers",
+			"cs": "Conductive Polymers"
+		},
+		"Configurable Components": {
+			"es": "Componentes Configurables",
+			"pt": "Componentes Configuráveis",
+			"de": "Konfigurierbare Komponenten",
+			"fr": "Composant paramétrables",
+			"ru": "Настраиваемые компоненты",
+			"pl": "Configurable Components",
+			"cs": "Configurable Components"
+		},
+		"Core Dynamics Composites": {
+			"es": "Compuestos de Core Dynamics",
+			"pt": "Componentes da Core Dynamics",
+			"de": "Core Dynamics Kompositwerkstoffe",
+			"fr": "Composites Core Dynamics",
+			"ru": "Композиты Core Dynamics",
+			"pl": "Core Dynamics Composites",
+			"cs": "Core Dynamics Composites"
+		},
+		"Cracked Industrial Firmware": {
+			"es": "Firmware Industrial Pirateado",
+			"pt": "Firmware Industrial Quebrado",
+			"de": "Gecrackte Industrie-Firmware",
+			"fr": "Micrologiciel industriel piraté",
+			"ru": "Взломанные промышленные микропрограммы",
+			"pl": "Cracked Industrial Firmware",
+			"cs": "Cracked Industrial Firmware"
+		},
+		"Crystal Shards": {
+			"es": "Piedras de Cristal",
+			"pt": "Fragmentos de Cristais",
+			"de": "Kristallscherben",
+			"fr": "Eclat de cristal",
+			"ru": "Осколки кристаллов",
+			"pl": "Crystal Shards",
+			"cs": "Crystal Shards"
+		},
+		"Datamined Wake Exceptions": {
+			"es": "Excepciones en Análisis de Estelas",
+			"pt": "Exceções de Dados Processados de Rastros",
+			"de": "FSA-Daten-Cache-Ausnahmen",
+			"fr": "Exploration de données de sillage anormales",
+			"ru": "Исключения из глубинного анализа данных следа",
+			"pl": "Datamined Wake Exceptions",
+			"cs": "Datamined Wake Exceptions"
+		},
+		"Decoded Emission Data": {
+			"es": "Datos de Emisión Descodificados",
+			"pt": "Dados de Emissão Decodificados",
+			"de": "Entschlüsselte Emissionsdaten",
+			"fr": "Données d'émissions décodées",
+			"ru": "Расшифрованные данные об излучении",
+			"pl": "Decoded Emission Data",
+			"cs": "Decoded Emission Data"
+		},
+		"Distorted Shield Cycle Recordings": {
+			"es": "Registros de Ciclo de Escudo Distorsionados",
+			"pt": "Registros Distorcidos de Ciclos de Escudo",
+			"de": "Gestörte Schildzyklus-Aufzeichnungen",
+			"fr": "Enregistrements de cycles de bouclier déformés",
+			"ru": "Поврежденные цикличные записи щита",
+			"pl": "Distorted Shield Cycle Recordings",
+			"cs": "Distorted Shield Cycle Recordings"
+		},
+		"Divergent Scan Data": {
+			"es": "Datos de Escáner Divergentes",
+			"pt": "Dados Escaneados Divergentes",
+			"de": "Divergente Scandaten",
+			"fr": "Données d'analyse divergentes",
+			"ru": "Неформатные данные сканирования",
+			"pl": "Divergent Scan Data",
+			"cs": "Divergent Scan Data"
+		},
+		"Eccentric Hyperspace Trajectories": {
+			"es": "Trayectorias de Hiperespacio Excéntricas",
+			"pt": "Trajetórias Escêntricas de Hiperespaço",
+			"de": "Exzentrische Hyperraum-Routen",
+			"fr": "Trajectoires hyperespace exentriques",
+			"ru": "Аномальные траектории в гиперпространстве",
+			"pl": "Eccentric Hyperspace Trajectories",
+			"cs": "Eccentric Hyperspace Trajectories"
+		},
+		"Electrochemical Arrays": {
+			"es": "Matriz Electroquímica",
+			"pt": "Matrizes Eletroquímicas",
+			"de": "Elektrochemische Detektoren",
+			"fr": "Réseaux électrochimiques",
+			"ru": "Электрохимические массивы",
+			"pl": "Electrochemical Arrays",
+			"cs": "Electrochemical Arrays"
+		},
+		"Emergency Power Cells": {
+			"es": "Celulas de Energía de Emergencia",
+			"pt": "Baterias de emergência",
+			"de": "Notfall-Energiezellen",
+			"fr": "Cellules d'énergie d'urgence",
+			"ru": "Аварийные энергоячейки",
+			"pl": "Emergency Power Cells",
+			"cs": "Emergency Power Cells"
+		},
+		"Energy Grid Assembly": {
+			"es": "Red de Energía",
+			"pt": "Montagem de rede de energia",
+			"de": "Energienetz-Gruppe",
+			"fr": "Système de réseau d'alimentation",
+			"ru": "Электросеть в сборе",
+			"pl": "Energy Grid Assembly",
+			"cs": "Energy Grid Assembly"
+		},
+		"Exceptional Scrambled Emission Data": {
+			"es": "Datos de Transmisiones Codificadas Excepcionales",
+			"pt": "Exceções nos Dados de Emissão Embaralhados",
+			"de": "Außergewöhnliche verschlüsselte Emissionsdaten",
+			"fr": "Données d'émissions brouillées exceptionnelles",
+			"ru": "Исключительные зашифрованные данные об излучении",
+			"pl": "Exceptional Scrambled Emission Data",
+			"cs": "Exceptional Scrambled Emission Data"
+		},
+		"Exhaust Manifold": {
+			"es": "Colector de Escape",
+			"pt": "Tubo exaustor",
+			"de": "Krümmer",
+			"fr": "Collecteur d'échappement",
+			"ru": "Выпускной коллектор",
+			"pl": "Exhaust Manifold",
+			"cs": "Exhaust Manifold"
+		},
+		"Exquisite Focus Crystals": {
+			"es": "Cristales de Enfoque Exquisitos",
+			"pt": "Cristais de Focalização Finos",
+			"de": "Erlesene Laserkristalle",
+			"fr": "Cristaux de focalisation sans défaut",
+			"ru": "Отборные фокусировочные кристаллы",
+			"pl": "Exquisite Focus Crystals",
+			"cs": "Exquisite Focus Crystals"
+		},
+		"Filament Composites": {
+			"es": "Compuestos de Filamentos",
+			"pt": "Compostos De Filamentos",
+			"de": "Filament-Komposite",
+			"fr": "Composites filamentaires",
+			"ru": "Волокнистые композиты",
+			"pl": "Filament Composites",
+			"cs": "Filament Composites"
+		},
+		"Flawed Focus Crystals": {
+			"es": "Cristales de Enfoque Defectuosos",
+			"pt": "Cristais de Focalização Falhos",
+			"de": "Fehlerhafte Fokuskristalle",
+			"fr": "Cristaux de focalisation imparfaits",
+			"ru": "Поврежденные фокусировочные кристаллы",
+			"pl": "Flawed Focus Crystals",
+			"cs": "Flawed Focus Crystals"
+		},
+		"Focus Crystals": {
+			"es": "Cristales de Enfoque",
+			"pt": "Cristais de Focalização",
+			"de": "Laserkristalle",
+			"fr": "Cristaux de focalisation",
+			"ru": "Фокусировочные кристаллы",
+			"pl": "Focus Crystals",
+			"cs": "Focus Crystals"
+		},
+		"Galvanising Alloys": {
+			"es": "Aleaciones Galvanizadas",
+			"pt": "Ligas Galvanizadas",
+			"de": "Galvanisierende Legierungen",
+			"fr": "Alliage galvanique",
+			"ru": "Сплавы для гальванизации",
+			"pl": "Galvanising Alloys",
+			"cs": "Galvanising Alloys"
+		},
+		"Germanium": {
+			"es": "Germanio",
+			"pt": "Germânio",
+			"de": "Germanium",
+			"fr": "Germanium",
+			"ru": "Германий",
+			"pl": "Germanium",
+			"cs": "Germanium"
+		},
+		"Grid Resistors": {
+			"es": "Red Resistiva",
+			"pt": "Resistores de Grade",
+			"de": "Gitterwiderstände",
+			"fr": "Résistance à grille",
+			"ru": "Наборные резисторы",
+			"pl": "Grid Resistors",
+			"cs": "Grid Resistors"
+		},
+		"Hardware Diagnostic Sensor": {
+			"es": "Sensor de Diagnóstico de Hardware",
+			"pt": "Sensor de diagnóstico de equipamentos",
+			"de": "Hardware-Diagnostiksensor",
+			"fr": "Capteur de diagnostic matériel",
+			"ru": "Сенсор диагностики оборудования",
+			"pl": "Hardware Diagnostic Sensor",
+			"cs": "Hardware Diagnostic Sensor"
+		},
+		"Heat Conduction Wiring": {
+			"es": "Cableado de Conducción Calorífica",
+			"pt": "Fiação De Condução Térmica",
+			"de": "Wärmeleitungsverdrahtung",
+			"fr": "Câblage de conduction thermique",
+			"ru": "Теплопроводящие провода",
+			"pl": "Heat Conduction Wiring",
+			"cs": "Heat Conduction Wiring"
+		},
+		"Heat Dispersion Plate": {
+			"es": "Placa de Dispersión de Calor",
+			"pt": "Placa de Dispersão Térmica",
+			"de": "Wärmeverteilungsplatte",
+			"fr": "Plaque de dissipation thermique",
+			"ru": "Теплорассеивающая пластина",
+			"pl": "Heat Dispersion Plate",
+			"cs": "Heat Dispersion Plate"
+		},
+		"Heat Exchangers": {
+			"es": "Intercambiadores de Calor",
+			"pt": "Trocadores Térmicos",
+			"de": "Wärmeaustauscher",
+			"fr": "Echangeurs de chaleur",
+			"ru": "Теплообменные агрегаты",
+			"pl": "Heat Exchangers",
+			"cs": "Heat Exchangers"
+		},
+		"Heat Resistant Ceramics": {
+			"es": "Cerámicas Resistentes al Calor",
+			"pt": "Cêramicas Termoresistentes",
+			"de": "Hitzefeste Keramik",
+			"fr": "Céramiques résistantes à la chaleur",
+			"ru": "Жаропрочная керамика",
+			"pl": "Heat Resistant Ceramics",
+			"cs": "Heat Resistant Ceramics"
+		},
+		"Heat Vanes": {
+			"es": "Palas Térmicas",
+			"pt": "Ventoinha Térmica",
+			"de": "Wärmeleitbleche",
+			"fr": "Vannes thermiques",
+			"ru": "Тепловые заслонки",
+			"pl": "Heat Vanes",
+			"cs": "Heat Vanes"
+		},
+		"Heatsink Interlink": {
+			"es": "Interconectores de Eyector Térmico",
+			"pt": "Dissipador térmico entrelaçado",
+			"de": "Kühlkörperverbinder",
+			"fr": "Interconnexion de dissipateur",
+			"ru": "Радиаторный соединитель",
+			"pl": "Heatsink Interlink",
+			"cs": "Heatsink Interlink"
+		},
+		"High Density Composites": {
+			"es": "Compuestos de Alta Densidad",
+			"pt": "Compostos de alta densidade",
+			"de": "Komposite hoher Dichte",
+			"fr": "Composites à haute densité",
+			"ru": "Высокоплотностные композиты",
+			"pl": "High Density Composites",
+			"cs": "High Density Composites"
+		},
+		"HN Shock Mount": {
+			"es": "Suspensión HN",
+			"pt": "Montagem de choque HN",
+			"de": "HN-Dämpferaufhängung",
+			"fr": "Protection antichoc HP",
+			"ru": "Разрядная установка HN",
+			"pl": "HN Shock Mount",
+			"cs": "HN Shock Mount"
+		},
+		"Hybrid Capacitors": {
+			"es": "Capacitadores Híbridos",
+			"pt": "Capacitores Híbridos",
+			"de": "Hybridkondensatoren",
+			"fr": "Condensateurs hybrides",
+			"ru": "Гибридные конденсаторы",
+			"pl": "Hybrid Capacitors",
+			"cs": "Hybrid Capacitors"
+		},
+		"Imperial Shielding": {
+			"es": "Escudos Imperiales",
+			"pt": "Proteção Imperial",
+			"de": "Imperiale Schilde",
+			"fr": "Protection impériale",
+			"ru": "Имперская защита",
+			"pl": "Imperial Shielding",
+			"cs": "Imperial Shielding"
+		},
+		"Improvised Components": {
+			"es": "Componentes Improvisados",
+			"pt": "Componentes Improvisados",
+			"de": "Behelfskomponenten",
+			"fr": "Composants improvisés",
+			"ru": "Кустарные компоненты",
+			"pl": "Improvised Components",
+			"cs": "Improvised Components"
+		},
+		"Inconsistent Shield Soak Analysis": {
+			"es": "Analisis de Absorcion de Esucudos Inconsistente",
+			"pt": "Análise Inconsistente de Escudo Atingidos",
+			"de": "Inkonsistente Schildleistungsanalyse",
+			"fr": "Analyse d'absorption de bouclier incohérente",
+			"ru": "Неполный анализ поглощения щита",
+			"pl": "Inconsistent Shield Soak Analysis",
+			"cs": "Inconsistent Shield Soak Analysis"
+		},
+		"Insulating Membrane": {
+			"es": "Membrana Aislante",
+			"pt": "Membrana de isolamento",
+			"de": "Isoliermembran",
+			"fr": "Membrane isolante",
+			"ru": "Изолирующая мембрана",
+			"pl": "Insulating Membrane",
+			"cs": "Insulating Membrane"
+		},
+		"Ion Distributor": {
+			"es": "Distribuidor de Iones",
+			"pt": "Distribuidor de íon",
+			"de": "Ionenverteiler",
+			"fr": "Distributeur d'ions",
+			"ru": "Ионный распределитель",
+			"pl": "Ion Distributor",
+			"cs": "Ion Distributor"
+		},
+		"Iron": {
+			"es": "Hierro",
+			"pt": "Ferro",
+			"de": "Eisen",
+			"fr": "Fer",
+			"ru": "Железо",
+			"pl": "Iron",
+			"cs": "Iron"
+		},
+		"Irregular Emission Data": {
+			"es": "Datos de Emisión Irregulares",
+			"pt": "Dados de Emissão Irregulares",
+			"de": "Irreguläre Emissionsdaten",
+			"fr": "Données d'émissions aberrantes",
+			"ru": "Нестандартные данные об излучении",
+			"pl": "Irregular Emission Data",
+			"cs": "Irregular Emission Data"
+		},
+		"Magnetic Emitter Coil": {
+			"es": "Bobina de Emisión Magnética",
+			"pt": "Bobina de emissão magnética",
+			"de": "Magnetische Emitterspule",
+			"fr": "Bobine d'émission magnétique",
+			"ru": "Спираль магнитного излучателя",
+			"pl": "Magnetic Emitter Coil",
+			"cs": "Magnetic Emitter Coil"
+		},
+		"Manganese": {
+			"es": "Manganeso",
+			"pt": "Manganês",
+			"de": "Mangan",
+			"fr": "Manganese",
+			"ru": "Марганец",
+			"pl": "Manganese",
+			"cs": "Manganese"
+		},
+		"Mechanical Components": {
+			"es": "Componentes Mecánicos",
+			"pt": "Componentes Mecânicos",
+			"de": "Mechanische Komponenten",
+			"fr": "Composants mécaniques",
+			"ru": "Механические компоненты",
+			"pl": "Mechanical Components",
+			"cs": "Mechanické komponenty"
+		},
+		"Mechanical Equipment": {
+			"es": "Equipamiento Mecánico",
+			"pt": "Equipamento Mecânico",
+			"de": "Mechanisches Equipment",
+			"fr": "Equipement mécanique",
+			"ru": "Механическое оборудование",
+			"pl": "Mechanical Equipment",
+			"cs": "Mechanical Equipment"
+		},
+		"Mechanical Scrap": {
+			"es": "Chatarra Mecánica",
+			"pt": "Sucata Mecânica",
+			"de": "Mechanischer Schrott",
+			"fr": "Ferraille mécanique",
+			"ru": "Механические отходы",
+			"pl": "Mechanical Scrap",
+			"cs": "Mechanical Scrap"
+		},
+		"Mercury": {
+			"es": "Mercurio",
+			"pt": "Mercúrio",
+			"de": "Quecksilber",
+			"fr": "Mercure",
+			"ru": "Ртуть",
+			"pl": "Mercury",
+			"cs": "Mercury"
+		},
+		"Micro Controllers": {
+			"es": "Microcontroladores",
+			"pt": "Microcontroladores",
+			"de": "Mikrocontroller",
+			"fr": "Microcontrôleurs",
+			"ru": "Микроконтроллеры",
+			"pl": "Micro Controllers",
+			"cs": "Micro Controllers"
+		},
+		"Micro-Weave Cooling Hoses": {
+			"es": "Mangueras de Refrigeración de Micro-tejidos",
+			"pt": "Mangueiras de resfriamento por micro-ondas",
+			"de": "Mikroflecht-Kühlschläuche",
+			"fr": "Tuyaux de refroidissement à microfilaments",
+			"ru": "Шланги системы охлаждения малых диаметров",
+			"pl": "Micro-Weave Cooling Hoses",
+			"cs": "Micro-Weave Cooling Hoses"
+		},
+		"Military Grade Alloys": {
+			"es": "Aleaciones de Grado Militar",
+			"pt": "Ligas nível militar",
+			"de": "Militärqualitätslegierungen",
+			"fr": "Alliages militaires",
+			"ru": "Сплавы военного назначения",
+			"pl": "Military Grade Alloys",
+			"cs": "Military Grade Alloys"
+		},
+		"Military Supercapacitors": {
+			"es": "Supercapacitadores Militares",
+			"pt": "Supercapacitores militares",
+			"de": "Militärische Superkondensatoren",
+			"fr": "Supercondensateurs militaires",
+			"ru": "Военные суперконденсаторы",
+			"pl": "Military Supercapacitors",
+			"cs": "Military Supercapacitors"
+		},
+		"Modified Consumer Firmware": {
+			"es": "Firmware de Consumo Modificado",
+			"pt": "Firmware de Consumo Modificado",
+			"de": "Modifizierte Consumer-Firmware",
+			"fr": "Micrologiciel consommateur modifié",
+			"ru": "Измененные пользовательские микропрограммы",
+			"pl": "Modified Consumer Firmware",
+			"cs": "Modified Consumer Firmware"
+		},
+		"Modified Embedded Firmware": {
+			"es": "Firmware Integrado Modificado",
+			"pt": "Firmware Embutido Modificado",
+			"de": "Modifizierte integrierte Firmware",
+			"fr": "Micrologiciel intégré modifié",
+			"ru": "Измененные встроенные микропрограммы",
+			"pl": "Modified Embedded Firmware",
+			"cs": "Modified Embedded Firmware"
+		},
+		"Modular Terminals": {
+			"es": "Terminales Modulares",
+			"pt": "Terminais modulares",
+			"de": "Modulterminals",
+			"fr": "Terminaux modulaires",
+			"ru": "Модульные терминалы",
+			"pl": "Modular Terminals",
+			"cs": "Modular Terminals"
+		},
+		"Molybdenum": {
+			"es": "Molibdeno",
+			"pt": "Molibdênio",
+			"de": "Molibdän",
+			"fr": "Molybdene",
+			"ru": "Молибден",
+			"pl": "Molybdenum",
+			"cs": "Molybdenum"
+		},
+		"Nanobreakers": {
+			"es": "Nanorrompedores",
+			"pt": "Nanodisjuntores",
+			"de": "Nanozertrümmerer",
+			"fr": "Nanodestructeurs",
+			"ru": "Нанопрерыватели",
+			"pl": "Nanobreakers",
+			"cs": "Nanobreakers"
+		},
+		"Neofabric Insulation": {
+			"es": "Neotejido Aislante",
+			"pt": "Neotecido de isolamento",
+			"de": "Neogewebe-Isolierung",
+			"fr": "Isolant en néotextile",
+			"ru": "Высокотехнологичная изоляция",
+			"pl": "Neofabric Insulation",
+			"cs": "Neofabric Insulation"
+		},
+		"Nickel": {
+			"es": "Níquel",
+			"pt": "Níquel",
+			"de": "Nickel",
+			"fr": "Nickel",
+			"ru": "Никель",
+			"pl": "Nickel",
+			"cs": "Nickel"
+		},
+		"Niobium": {
+			"es": "Niobio",
+			"pt": "Nióbio",
+			"de": "Niobium",
+			"fr": "Niobium",
+			"ru": "Ниобий",
+			"pl": "Niobium",
+			"cs": "Niobium"
+		},
+		"Open Symmetric Keys": {
+			"es": "Claves Simétricas Abiertas",
+			"pt": "Chaves Simétricas Abertas",
+			"de": "Offene symmetrische Schlüssel",
+			"fr": "clés symétriques ouvertes",
+			"ru": "Открытые симметричные ключи",
+			"pl": "Open Symmetric Keys",
+			"cs": "Open Symmetric Keys"
+		},
+		"Osmium": {
+			"es": "Osmio",
+			"pt": "Ósmio",
+			"de": "Osmium",
+			"fr": "Osmium",
+			"ru": "Осмий",
+			"pl": "Osmium",
+			"cs": "Osmium"
+		},
+		"Pattern Alpha Obelisk Data": {
+			"es": "Datos de Obelisco de Patrón Alpha",
+			"pt": "Dados de Obelisco de Padrão Alfa",
+			"de": "Alpha-Muster-Obeliskendaten",
+			"fr": "Données d'obélisque de type alpha",
+			"ru": "Данные с обелиска «Альфа»",
+			"pl": "Pattern Alpha Obelisk Data",
+			"cs": "Pattern Alpha Obelisk Data"
+		},
+		"Pattern Beta Obelisk Data": {
+			"es": "Datos de Obelisco de Patrón Beta",
+			"pt": "Dados de Obelisco de Padrão Beta",
+			"de": "Beta-Muster-Obeliskendaten",
+			"fr": "Données d'obélisque de type Beta",
+			"ru": "Данные с обелиска «Бета»",
+			"pl": "Pattern Beta Obelisk Data",
+			"cs": "Pattern Beta Obelisk Data"
+		},
+		"Pattern Delta Obelisk Data": {
+			"es": "Datos de Obelisco de Patrón Delta",
+			"pt": "Dados de Obelisco de Padrão Delta",
+			"de": "Delta-Muster-Obeliskendaten",
+			"fr": "Données d'obélisque de type Delta",
+			"ru": "Данные с обелиска «Дельта»",
+			"pl": "Pattern Delta Obelisk Data",
+			"cs": "Pattern Delta Obelisk Data"
+		},
+		"Pattern Epsilon Obelisk Data": {
+			"es": "Datos de Obelisco de Patrón Epsilon",
+			"pt": "Dados de Obelisco de Padrão Epsilon",
+			"de": "Epsilon-Muster-Obeliskendaten",
+			"fr": "Données d'obélisque de type Epsilon",
+			"ru": "Данные с обелиска «Эпсилон»",
+			"pl": "Pattern Epsilon Obelisk Data",
+			"cs": "Pattern Epsilon Obelisk Data"
+		},
+		"Pattern Gamma Obelisk Data": {
+			"es": "Datos de Obelisco de Patrón Gamma",
+			"pt": "Dados de Obelisco de Padrão Gama",
+			"de": "Gamma-Muster-Obeliskendaten",
+			"fr": "Données d'obélisque de type Gamma",
+			"ru": "Данные с обелиска «Гамма»",
+			"pl": "Pattern Gamma Obelisk Data",
+			"cs": "Pattern Gamma Obelisk Data"
+		},
+		"Peculiar Shield Frequency Data": {
+			"es": "Datos de Frecuencias de Escudo Peculiares",
+			"pt": "Dados da Frequência de Escudos Peculiares",
+			"de": "Verdächtige Schildfrequenz-Daten",
+			"fr": "Données de Fréquences de bouclier Singulières",
+			"ru": "Специфические данные о частоте щитов",
+			"pl": "Peculiar Shield Frequency Data",
+			"cs": "Peculiar Shield Frequency Data"
+		},
+		"Pharmaceutical Isolators": {
+			"es": "Aislantes Farmacéuticos",
+			"pt": "Isolantes farmacêuticos",
+			"de": "Pharmazeutische Isolatoren",
+			"fr": "Isolants pharmaceutiques",
+			"ru": "Фармацевтические изоляционные материалы",
+			"pl": "Pharmaceutical Isolators",
+			"cs": "Pharmaceutical Isolators"
+		},
+		"Phase Alloys": {
+			"es": "Aleaciones de Fase",
+			"pt": "Ligas de Fase",
+			"de": "Phasenlegierungen",
+			"fr": "Alliages de phase",
+			"ru": "Фазовые сплавы",
+			"pl": "Phase Alloys",
+			"cs": "Phase Alloys"
+		},
+		"Phosphorus": {
+			"es": "Fósforo",
+			"pt": "Fósforo",
+			"de": "Phosphor",
+			"fr": "Phosphore",
+			"ru": "Фосфор",
+			"pl": "Phosphorus",
+			"cs": "Phosphorus"
+		},
+		"Platinum": {
+			"es": "Platino",
+			"pt": "Platina",
+			"de": "Platin",
+			"fr": "platinium",
+			"ru": "Платина",
+			"pl": "Platinum",
+			"cs": "Platinum"
+		},
+		"Polonium": {
+			"es": "Polonio",
+			"pt": "Polônio",
+			"de": "Polonium",
+			"fr": "Polonium",
+			"ru": "Полоний",
+			"pl": "Polonium",
+			"cs": "Polonium"
+		},
+		"Polymer Capacitors": {
+			"es": "Capacitadores de Polímeros",
+			"pt": "Capacitores de Polímeros",
+			"de": "Polymerkondensatoren",
+			"fr": "Condensateurs en polymères",
+			"ru": "Полимерные конденсаторы",
+			"pl": "Polymer Capacitors",
+			"cs": "Polymer Capacitors"
+		},
+		"Power Converter": {
+			"es": "Convertidor de Energía",
+			"pt": "Conversor de energia",
+			"de": "Energiekonverter",
+			"fr": "Convertisseur de puissance",
+			"ru": "Преобразователь энергии",
+			"pl": "Power Converter",
+			"cs": "Power Converter"
+		},
+		"Power Transfer Bus": {
+			"es": "Conductos de Transferencia de Energía",
+			"pt": "Dutos de transferência de energia",
+			"de": "Energietransferbus",
+			"fr": "Conduit de transfert d’énergie",
+			"ru": "Энергообменная шина",
+			"pl": "Power Transfer Bus",
+			"cs": "Power Transfer Bus"
+		},
+		"Praseodymium": {
+			"es": "Praseodimio",
+			"pt": "Praseodímio",
+			"de": "Praseodym",
+			"fr": "Praseodyme",
+			"ru": "Празеодим",
+			"pl": "Praseodymium",
+			"cs": "Praseodymium"
+		},
+		"Precipitated Alloys": {
+			"es": "Aleaciones de Precipitación",
+			"pt": "Ligas Precipitadas",
+			"de": "Gehärtete Legierungen",
+			"fr": "Alliages précipités",
+			"ru": "Осажденные сплавы",
+			"pl": "Precipitated Alloys",
+			"cs": "Precipitated Alloys"
+		},
+		"Proprietary Composites": {
+			"es": "Compuestos con Patente",
+			"pt": "Compostos Propietários",
+			"de": "Kompositwerkstoffe",
+			"fr": "Composites brevetés",
+			"ru": "Патентованные композиты",
+			"pl": "Proprietary Composites",
+			"cs": "Proprietary Composites"
+		},
+		"Proto Heat Radiators": {
+			"es": "Protorradiadores Térmicos",
+			"pt": "Proto radiadores térmicos",
+			"de": "Proto-Wärmestrahler",
+			"fr": "Proto-radiateurs",
+			"ru": "Прототипы теплоизлучателей",
+			"pl": "Proto Heat Radiators",
+			"cs": "Proto Heat Radiators"
+		},
+		"Proto Light Alloys": {
+			"es": "Protoaleaciones Ligeras",
+			"pt": "Proto ligas leves",
+			"de": "Leichte Legierungen (Proto)",
+			"fr": "Proto-alliages légers",
+			"ru": "Опытные легкие сплавы",
+			"pl": "Proto Light Alloys",
+			"cs": "Proto Light Alloys"
+		},
+		"Proto Radiolic Alloys": {
+			"es": "Aleaciones Protorradiadas",
+			"pt": "Proto ligas radiólicas",
+			"de": "Radiologische Legierungen (Proto)",
+			"fr": "Proto-alliages radiologiques",
+			"ru": "Сплавы для изготовления зондов",
+			"pl": "Proto Radiolic Alloys",
+			"cs": "Proto Radiolic Alloys"
+		},
+		"Radiation Baffle": {
+			"es": "Deflector de Radiación",
+			"pt": "Defletor de radiação",
+			"de": "Strahlungsabweiser",
+			"fr": "Ecran antiradiation",
+			"ru": "Отражатель излучения",
+			"pl": "Radiation Baffle",
+			"cs": "Radiation Baffle"
+		},
+		"Refined Focus Crystals": {
+			"es": "Cristales de Enfoque Refinados",
+			"pt": "Cristais de focalização refinado",
+			"de": "Raffinierte Laserkristalle",
+			"fr": "Cristaux de focalisation raffinés",
+			"ru": "Обработанные фокусировочные кристаллы",
+			"pl": "Refined Focus Crystals",
+			"cs": "Refined Focus Crystals"
+		},
+		"Reinforced Mounting Plate": {
+			"es": "Placa de Anclaje Reforzada",
+			"pt": "Placa de montagem reforçada",
+			"de": "Verstärkte Trägerplatte",
+			"fr": "Plaque de montage renforcée",
+			"ru": "Усиленная монтажная плита",
+			"pl": "Reinforced Mounting Plate",
+			"cs": "Reinforced Mounting Plate"
+		},
+		"Ruthenium": {
+			"es": "Rutenio",
+			"pt": "Rutênio",
+			"de": "Ruthenium",
+			"fr": "Ruthenium",
+			"ru": "Рутений",
+			"pl": "Ruthenium",
+			"cs": "Ruthenium"
+		},
+		"Rhenium": {
+			"es": null,
+			"pt": "Rênio",
+			"de": "Rhenium",
+			"fr": null,
+			"ru": "Рений",
+			"pl": null,
+			"cs": "Rhenium"
+		},
+		"Salvaged Alloys": {
+			"es": "Aleaciones Recuperadas",
+			"pt": "Ligas recuperadas",
+			"de": "Geborgene Legierungen",
+			"fr": "Alliages récupérés",
+			"ru": "Захваченные сплавы",
+			"pl": "Salvaged Alloys",
+			"cs": "Salvaged Alloys"
+		},
+		"Samarium": {
+			"es": "Samario",
+			"pt": "Samário",
+			"de": "Samarium",
+			"fr": "Samarium",
+			"ru": "Самарий",
+			"pl": "Samarium",
+			"cs": "Samarium"
+		},
+		"Security Firmware Patch": {
+			"es": "Parche de Firmware de Seguridad",
+			"pt": "Atualização de firmware de segurança",
+			"de": "Sicherheits-Firmware-Patch",
+			"fr": "Mise à jour de micrologiciel de sécurité",
+			"ru": "Обновление для защитной микропрограммы",
+			"pl": "Security Firmware Patch",
+			"cs": "Security Firmware Patch"
+		},
+		"Selenium": {
+			"es": "Selenio",
+			"pt": "Selênio",
+			"de": "Selen",
+			"fr": "Selenium",
+			"ru": "Селен",
+			"pl": "Selenium",
+			"cs": "Selenium"
+		},
+		"Shield Emitters": {
+			"es": "Emisores de Escudo",
+			"pt": "Emissores de escudo",
+			"de": "Schildemitter",
+			"fr": "Emetteurs de bouclier",
+			"ru": "Щитоизлучатели",
+			"pl": "Shield Emitters",
+			"cs": "Shield Emitters"
+		},
+		"Shielding Sensors": {
+			"es": "Sensores de Escudo",
+			"pt": "Sensores para proteção",
+			"de": "Schildsensoren",
+			"fr": "Capteurs de bouclier",
+			"ru": "Сенсоры системы экранирования",
+			"pl": "Shielding Sensors",
+			"cs": "Shielding Sensors"
+		},
+		"Specialised Legacy Firmware": {
+			"es": "Firmware Heredado Especializado",
+			"pt": "Firmware especializado antigo",
+			"de": "Spezial-Legacy-Firmware",
+			"fr": "Micrologiciel spécialisé périmé",
+			"ru": "Специальные микропрограммы предыдущего поколения",
+			"pl": "Specialised Legacy Firmware",
+			"cs": "Specialised Legacy Firmware"
+		},
+		"Strange Wake Solutions": {
+			"es": "Extrañas Soluciones de Estelas",
+			"pt": "Soluções de rastro estranhas",
+			"de": "Seltsame FSA-Zielorte",
+			"fr": "Solutions de sillages anormales",
+			"ru": "Странные расчеты следа",
+			"pl": "Strange Wake Solutions",
+			"cs": "Strange Wake Solutions"
+		},
+		"Sulphur": {
+			"es": "Azufre",
+			"pt": "Enxofre",
+			"de": "Schwefel",
+			"fr": "Souffre",
+			"ru": "Сера",
+			"pl": "Sulphur",
+			"cs": "Sulphur"
+		},
+		"Tagged Encryption Codes": {
+			"es": "Códigos de Encriptación Marcados",
+			"pt": "Código de encriptação rotulados",
+			"de": "Getaggte Verschlüsselungscodes",
+			"fr": "Clés de cryptage balisées",
+			"ru": "Меченые шифровальные коды",
+			"pl": "Tagged Encryption Codes",
+			"cs": "Tagged Encryption Codes"
+		},
+		"Technetium": {
+			"es": "Tecnecio",
+			"pt": "Tecnécio",
+			"de": "Technetium",
+			"fr": "Technetium",
+			"ru": "Технеций",
+			"pl": "Technetium",
+			"cs": "Technetium"
+		},
+		"Telemetry Suite": {
+			"es": "Paquete de Telemetría",
+			"pt": "Conjunto de telemetria",
+			"de": "Telemetrie-Paket",
+			"fr": "Système de télémétrie",
+			"ru": "Телеметрический комплект",
+			"pl": "Telemetry Suite",
+			"cs": "Telemetry Suite"
+		},
+		"Tellurium": {
+			"es": "Teluro",
+			"pt": "Telúrio",
+			"de": "Tellur",
+			"fr": "Tellure",
+			"ru": "Теллурий",
+			"pl": "Tellurium",
+			"cs": "Tellurium"
+		},
+		"Tempered Alloys": {
+			"es": "Aleaciones Templadas",
+			"pt": "Ligas temperadas",
+			"de": "Vergütete Legierungen",
+			"fr": "Alliages trempés",
+			"ru": "Закаленные сплавы",
+			"pl": "Tempered Alloys",
+			"cs": "Tempered Alloys"
+		},
+		"Thermic Alloys": {
+			"es": "Aleaciones Térmicas",
+			"pt": "Ligas térmicas",
+			"de": "Thermische Legierungen",
+			"fr": "Alliages thermiques",
+			"ru": "Термические сплавы",
+			"pl": "Thermic Alloys",
+			"cs": "Thermic Alloys"
+		},
+		"Tin": {
+			"es": "Estaño",
+			"pt": "Estanho",
+			"de": "Zinn",
+			"fr": "Etain",
+			"ru": "Олово",
+			"pl": "Tin",
+			"cs": "Tin"
+		},
+		"Tungsten": {
+			"es": "Tungsteno",
+			"pt": "Tungstênio",
+			"de": "Wolfram",
+			"fr": "Tungstène",
+			"ru": "Вольфрам",
+			"pl": "Tungsten",
+			"cs": "Tungsten"
+		},
+		"Unexpected Emission Data": {
+			"es": "Datos de Emisión Inesperados",
+			"pt": "Dados de emissão inesperados",
+			"de": "Unerwartete Emissionsdaten",
+			"fr": "Données d'émissions inattendues",
+			"ru": "Неожиданные данные об излучении",
+			"pl": "Unexpected Emission Data",
+			"cs": "Unexpected Emission Data"
+		},
+		"Unidentified Scan Archives": {
+			"es": "Archivos de Escáner no Identificados",
+			"pt": "Arquivos de escaneamento não identificados",
+			"de": "Unidentifizierte Scan-Archive",
+			"fr": "Données d'analyse archivées non identifiées",
+			"ru": "Неопознанные архивы сканирования",
+			"pl": "Unidentified Scan Archives",
+			"cs": "Unidentified Scan Archives"
+		},
+		"Sensor Fragment": {
+			"es": "Fragmento de sensor",
+			"pt": "Fragmento do sensor",
+			"de": "Unbekanntes Fragment",
+			"fr": "Fragment inconnu",
+			"ru": "Обломок сенсора",
+			"pl": "Sensor Fragment",
+			"cs": "Sensor Fragment"
+		},
+		"Untypical Shield Scans": {
+			"es": "Escáner de Escudos Atípico",
+			"pt": "Escaneamento de escudos atípicos",
+			"de": "Untypische Schildscans",
+			"fr": "Analyses de bouclier atypiques",
+			"ru": "Нетипичные данные сканирования щитов",
+			"pl": "Untypical Shield Scans",
+			"cs": "Untypical Shield Scans"
+		},
+		"Unusual Encrypted Files": {
+			"es": "Ficheros Encriptados Inusuales",
+			"pt": "Arquivos criptografados incomuns",
+			"de": "Ungewöhnliche verschlüsselte Files",
+			"fr": "Fichiers cryptés inhabituels",
+			"ru": "Особые зашифрованные файлы",
+			"pl": "Unusual Encrypted Files",
+			"cs": "Unusual Encrypted Files"
+		},
+		"Vanadium": {
+			"es": "Vanadio",
+			"pt": "Vanádio",
+			"de": "Vanadium",
+			"fr": "Vanadium",
+			"ru": "Ванадий",
+			"pl": "Vanadium",
+			"cs": "Vanadium"
+		},
+		"Worn Shield Emitters": {
+			"es": "Emisor de Escudos Desgastado",
+			"pt": "Emissores de Escudo Usado",
+			"de": "Gebrauchte Schildemitter",
+			"fr": "Émetteurs de bouclier usé",
+			"ru": "Изношенные щитоизлучатели",
+			"pl": "Worn Shield Emitters",
+			"cs": "Worn Shield Emitters"
+		},
+		"Yttrium": {
+			"es": "Ytrio",
+			"pt": "Ítrio",
+			"de": "Yttrium",
+			"fr": "Yttrium",
+			"ru": "Иттрий",
+			"pl": "Yttrium",
+			"cs": "Yttrium"
+		},
+		"Zinc": {
+			"es": "Zinc",
+			"pt": "Zinco",
+			"de": "Zink",
+			"fr": "Zinc",
+			"ru": "Цинк",
+			"pl": "Zinc",
+			"cs": "Zinc"
+		},
+		"Zirconium": {
+			"es": "Circonio",
+			"pt": "Zircônio",
+			"de": "Zirconium",
+			"fr": "Zirconium",
+			"ru": "Цирконий",
+			"pl": "Zirconium",
+			"cs": "Zirconium"
+		},
+		"ECM": {
+			"es": "Contramedida",
+			"pt": "CME",
+			"de": "EGM",
+			"fr": "CME",
+			"ru": "ЭПД",
+			"pl": "ECM",
+			"cs": "ECM"
+		},
+		"Hull": {
+			"es": "Casco",
+			"pt": "Casco",
+			"de": "Rumpfhülle",
+			"fr": "Coque",
+			"ru": "Корпус",
+			"pl": "Hull",
+			"cs": "Hull"
+		},
+		"FSD Interdictor": {
+			"es": "Interdictor",
+			"pt": "Interditor MDD",
+			"de": "FSA-Unterbrecher",
+			"fr": "Intercepteur FSD",
+			"ru": "Перехватчик FSD",
+			"pl": "FSD Interdictor",
+			"cs": "FSD Interdictor"
+		},
+		"Prospector LC": {
+			"es": "LD Prospector",
+			"pt": "Drone prospector",
+			"de": "DS Erzsucher",
+			"fr": "Contrôleur de drones Prospecteurs",
+			"ru": "Контроллер дронов геологов",
+			"pl": "Prospector LC",
+			"cs": "Prospector LC"
+		},
+		"Fuel Transfer LC": {
+			"es": "LD Repostaje",
+			"pt": "Drone de combustível",
+			"de": "DS Treibstofftransfer",
+			"fr": "Contrôleur de drones Ravitailleurs",
+			"ru": "Контроллер дронов заправщиков",
+			"pl": "Fuel Transfer LC",
+			"cs": "Fuel Transfer LC"
+		},
+		"Hatch Breaker LC": {
+			"es": "LD Extractor",
+			"pt": "Drone quebra-escotilha",
+			"de": "DS Ladelukenöffner",
+			"fr": "Contrôleur de drones Perce-Soute",
+			"ru": "Контроллер дронов взломщиков",
+			"pl": "Hatch Breaker LC",
+			"cs": "Hatch Breaker LC"
+		},
+		"Collector LC": {
+			"es": "LD Colector",
+			"pt": "Drone coletor",
+			"de": "DS Sammeldrohne",
+			"fr": "Contrôleur de drones Collecteurs",
+			"ru": "Контроллер дронов сборщиков",
+			"pl": "Collector LC",
+			"cs": "Collector LC"
+		},
+		"AFMU": {
+			"es": "Unidad de Automantenimiento",
+			"pt": "UMTS",
+			"de": "AFW",
+			"fr": "MTA",
+			"ru": "БАПР",
+			"pl": "AFMU",
+			"cs": "AFMU"
+		},
+		"Data": {
+			"es": "Datos",
+			"pt": "Dados",
+			"de": "Daten",
+			"fr": "Données",
+			"ru": "Данные",
+			"pl": "Dane",
+			"cs": "Data"
+		},
+		"Commodity": {
+			"es": "Mercancía",
+			"pt": "Mercadoria",
+			"de": "Handelsware",
+			"fr": "Marchandise",
+			"ru": "Товар",
+			"pl": "Towar",
+			"cs": "Komodita"
+		},
+		"Commodities": {
+			"es": "Mercancías",
+			"pt": "Marcadorias",
+			"de": "Handelswaren",
+			"fr": "Marchandises",
+			"ru": "Товары",
+			"pl": "Towary",
+			"cs": "Komodity"
+		},
+		"Material": {
+			"es": "Material",
+			"pt": "Material",
+			"de": "Material",
+			"fr": "Matériau",
+			"ru": "Материал",
+			"pl": "Materiały",
+			"cs": "Materiál"
+		},
+		"Materials": {
+			"es": "Materiales",
+			"pt": "Materiais",
+			"de": "Materialien",
+			"fr": "Matériaux",
+			"ru": "Материалы",
+			"pl": "Materiały",
+			"cs": "Materiály"
+		},
+		"Type": {
+			"es": "Tipo",
+			"pt": "Tipo",
+			"de": "Typ",
+			"fr": "Type",
+			"ru": "Тип",
+			"pl": "Typ",
+			"cs": "Typ"
+		},
+		"Name": {
+			"es": "Nombre",
+			"pt": "Nome",
+			"de": "Name",
+			"fr": "Nom",
+			"ru": "Название",
+			"pl": "Nazwa",
+			"cs": "Název"
+		},
+		"Progress": {
+			"es": "Progreso",
+			"pt": "Progresso",
+			"de": "Fortschritt",
+			"fr": "Progression",
+			"ru": "Прогресс",
+			"pl": "Postęp",
+			"cs": "Postup"
+		},
+		"Last update:": {
+			"es": "Ultima actualización",
+			"pt": "Última Atualização",
+			"de": "Letzte Aktualisierung:",
+			"fr": "Dernière Mise à jour",
+			"ru": "Последнее обновление:",
+			"pl": "Ostatnia aktualizacja:",
+			"cs": "Ostatní aktualizace:"
+		},
+		"Unlock Window": {
+			"es": "Desbloquear ventana",
+			"pt": "Desbloquear janela",
+			"de": "Fixierung aufheben",
+			"fr": "Débloquer la Fenêtre",
+			"ru": "Разблокировать окно",
+			"pl": "Odblokuj okno",
+			"cs": "Uvolni okno"
+		},
+		"Show entries with no stock?": {
+			"es": "¿Mostrar entradas sin stock?",
+			"pt": "Mostrar entradas sem estoque?",
+			"de": "Einträge ohne Bestand anzeigen?",
+			"fr": "Afficher les entrées sans stock?",
+			"ru": "Показывать пустые записи?",
+			"pl": "Pokaż składniki bez zapasów?",
+			"cs": "Zobrazit položky, které nemám ve skladu?"
+		},
+		"Show only for favorites?": {
+			"es": "¿Mostras sólo los favoritos?",
+			"pt": "Mostrar somente os favoritos?",
+			"de": "Nur Favoriten anzeigen?",
+			"fr": "Montrer uniquement les favoris?",
+			"ru": "Показывать только для избранных?",
+			"pl": "Pokaż składniki tylko dla ulubionych przepisów?",
+			"cs": "Zobrazit pouze oblíbené položky?"
+		},
+		"Grade Filter": {
+			"es": "Filtro de Grados",
+			"pt": "Filtro de grades",
+			"de": "Zugangsgrad Filter",
+			"fr": "Filtrer par Grades",
+			"ru": "Фильтр по уровню",
+			"pl": "Filtr poziomu",
+			"cs": "Filtrovat podle úrovně (Grade)"
+		},
+		"Engineer Filter": {
+			"es": "Filtro de Ingenieros",
+			"pt": "Filtro de engenheiros",
+			"de": "Ingenieur Filter",
+			"fr": "Filtrer par Ingénieurs",
+			"ru": "Фильтр по инженеру",
+			"pl": "Filtr inżyniera",
+			"cs": "Filtrovat podle inženýra"
+		},
+		"Type Filter": {
+			"es": "Filtro de Tipos",
+			"pt": "Filtro de tipos",
+			"de": "Typ Filter",
+			"fr": "Filtrer par Type",
+			"ru": "Фильтр по типу",
+			"pl": "Filtr typu",
+			"cs": "Filtrovat podle typu"
+		},
+		"Ignored And Favorite Filter": {
+			"es": "Filtro de Ignorados y Favoritos",
+			"pt": "Filtro de Ignorados e Favoritos",
+			"de": "Ignorierte und Favoriten Filter",
+			"fr": "Filtrer par Ignorés et Favoris",
+			"ru": "Фильтр по игнорируемым и избранным",
+			"pl": "Filtr ulubionych i ignorowanych",
+			"cs": "Filtrovat dle ignorovaných/oblíbených"
+		},
+		"Craftable Filter": {
+			"es": "Filtro de Elaborados",
+			"pt": "Filtro de produções",
+			"de": "Baubarkeit Filter",
+			"fr": "Filtrer par Craft disponible",
+			"ru": "Фильтр по доступности",
+			"pl": "Filtr możliwych do stworzenia",
+			"cs": "Filtr podle vyrobitelnosti"
+		},
+		"Ingredient Filter (Reversed)": {
+			"es": "Filtro de Ingredientes (Inverso)",
+			"pt": "Filtro de ingredientes (Inverter)",
+			"de": "Bestandteile Filter (invers)",
+			"fr": "Filtrer par Ingrédients (Inversé)",
+			"ru": "Фильтр по ингредиентам (Обратный)",
+			"pl": "Filtr składników (odwrócony)",
+			"cs": "Filtr ingrediencí (obrácený)"
+		},
+		"can craft": {
+			"es": "elaborable",
+			"pt": "Pode produzir",
+			"de": "baubar",
+			"fr": "dispos",
+			"ru": "можно создать",
+			"pl": "możesz stworzyć",
+			"cs": "Můžeš vyrobit"
+		},
+		"Reset": {
+			"es": "Reiniciar",
+			"pt": "Reiniciar",
+			"de": "Zurücksetzen",
+			"fr": "Reset",
+			"ru": "Сброс",
+			"pl": "Reset",
+			"cs": "Reset"
+		},
+		"Lock Window": {
+			"es": "Bloquear ventana",
+			"pt": "Bloquear janela",
+			"de": "Fenster fixieren",
+			"fr": "Bloquer la fenêtre",
+			"ru": "Заблокировать окно",
+			"pl": "Zablokuj okno",
+			"cs": "Zamkni okno"
+		},
+		"Show": {
+			"es": "Mostrar",
+			"pt": "Mostrar",
+			"de": "Anzeigen",
+			"fr": "Afficher",
+			"ru": "Открыть",
+			"pl": "Pokaż",
+			"cs": "Ukaž"
+		},
+		"Toggle Window Mode (Locked/Unlocked)": {
+			"es": "Cambiar el modo ventana (Bloqueado/Desbloqueado)",
+			"pt": "Alterar o modo janela (Bloqueado/Desbloquado)",
+			"de": "Fenster Modus umschalten (fixiert/freigegeben)",
+			"fr": "Mode de la fenêtre (Bloquer/arrière plan)",
+			"ru": "Переключить режим окна (Заблокировано/Разблокировано)",
+			"pl": "Przełącz tryb okna (zablokowany/odblokowany)",
+			"cs": "Prepni mód okna (zamčené/odemčené)"
+		},
+		"Reset Window Position": {
+			"es": "Restablecer la posición de la ventana",
+			"pt": "Reiniciar posição da janela",
+			"de": "Fensterposition zurücksetzen",
+			"fr": "Restaurer l'affichage de la fenêtre",
+			"ru": "Сбросить положение окна",
+			"pl": "Zresetuj położenie okna",
+			"cs": "Zresetuj pozici okna"
+		},
+		"Set Shortcut": {
+			"es": "Establecer acceso directo",
+			"pt": "Estabelecer acesso direto",
+			"de": "Tastenkombination setzen",
+			"fr": "Raccourcis",
+			"ru": "Настройка комбинации клавиш",
+			"pl": "Ustaw skrót",
+			"cs": "Nastav zkratku"
+		},
+		"Help": {
+			"es": "Ayuda",
+			"pt": "Ajuda",
+			"de": "Hilfe",
+			"fr": "Aide",
+			"ru": "Помощь",
+			"pl": "Pomoc",
+			"cs": "Pomoc"
+		},
+		"Quit": {
+			"es": "Salir",
+			"pt": "Sair",
+			"de": "Beenden",
+			"fr": "Quitter",
+			"ru": "Выйти",
+			"pl": "Wyjdź",
+			"cs": "Odejít"
+		},
+		"OK": {
+			"es": "OK",
+			"pt": "OK",
+			"de": "OK",
+			"fr": "OK",
+			"ru": "ОК",
+			"pl": "OK",
+			"cs": "OK"
+		},
+		"Cancel": {
+			"es": "Cancelar",
+			"pt": "Cancelar",
+			"de": "Abbrechen",
+			"fr": "Annuler",
+			"ru": "Отмена",
+			"pl": "Anuluj",
+			"cs": "Zrušit"
+		},
+		"Input a shortcut that's going to be used to show the window": {
+			"es": "Introduce el acceso directo que será utilizado para mostrar la ventana",
+			"pt": "Introduz um atalho que será utilizado para mostrar a janela",
+			"de": "Geben Sie eine Tastenkombination ein, die das Fenster anzeigt",
+			"fr": "Configurer une touche pour afficher la fenêtre",
+			"ru": "Нажмите комбинацию клавиш, которая будет раскрывать окно",
+			"pl": "Wprowadź skrót, który będzie wykorzystywany do przełączania okna",
+			"cs": "Zadejte zkratku, která se použije k zobrazení okna"
+		},
+		"You can't use an empty shortcut": {
+			"es": "No puedes usar un acceso directo vacío",
+			"pt": "Não é possível usar um atalho vazio",
+			"de": "Sie können keine leere Tastenkombination benutzen",
+			"fr": "Une touche doit être choisie",
+			"ru": "Вы не можете использовать пустую комбинацию клавиш",
+			"pl": "Nie możesz korzystać z pustego skrótu",
+			"cs": "Klávesová zkratka musí být vyplněna!"
+		},
+		"Error": {
+			"es": "Error",
+			"pt": "Erro",
+			"de": "Fehler",
+			"fr": "Erreur",
+			"ru": "Ошибка",
+			"pl": "Błąd",
+			"cs": "Chyba"
+		},
+		"The requested shortcut ({0}) is invalid": {
+			"es": "El acceso directo solicitado ({0}) no es válido",
+			"pt": "O atalho solicitado ({0}) é inválido",
+			"de": "Die gewünschte Tastenkombination ({0}) ist ungültig",
+			"fr": "La touche demandée ({0}) est invalide",
+			"ru": "Указанное сочетание клавиш ({0}) недействительно",
+			"pl": "Wybrany skrót ({0}) jest nieprawidłowy",
+			"cs": "Zvolená klávesová zkratka ({0}) je neplatná"
+		},
+		"You must use a regular key to accompany the modifier key like (Ctrl+F10 or Shift+R)": {
+			"es": "Debes utilizar una tecla normal para acompañar la tecla modificadora como (Ctrl+F10 or Shift+R)",
+			"pt": "Você deve usar uma tecla comum para acompanhar a tecla modificadora como (Ctrl+F10 ou Shift+R)",
+			"de": "Sie müssen eine reguläre Taste zusammen mit einer modifizierenden Taste verwenden wie (Strg+F10 or Shift+R)",
+			"fr": "Vous devez utiliser une touche normale pour accompagner la touche de modification comme (Ctrl + F10 ou Maj + R)",
+			"ru": "Вы должны использовать символьную клавишу вместе с клавишей-модификатором, например (Ctrl+F10 или Shift+R)",
+			"pl": "Musisz skorzystać z regularnego klawisza towarzyszącemu modyfikatorowi (np. Ctrl+F10 lub Shift+R)",
+			"cs": "Musíte použít standardní klávesu a pomocnou klávesu zároveň (např. Ctrl+F10 nebo Shift+R)"
+		},
+		"Something went wrong in parsing your logs, open an issue on GitHub with this information :": {
+			"es": "Se ha producido un error al analizar tus registros, envia una incidencia a GitHub con la siguiente información :",
+			"pt": "Algo deu errado na análise de seus logs, abra um problema no GitHub com esta informação",
+			"de": "Es ist ein Fehler beim Parsen Ihrer Logs aufgetreten, bitte öffnen Sie eine Issue-Meldung auf GitHub mit folgenden Angaben :",
+			"fr": "Erreur lors de la lecture de vos logs, merci d'ouvrir un ticket sur GitHub :",
+			"ru": "Что-то пошло не так при чтении ваших логов, создайте issue на GitHub c этой информацией :",
+			"pl": "Coś poszło nie tak podczas parsowania twoich logów, stwórz issue na GitHub-ie z tą informacją :",
+			"cs": "Nastal problém při parsování vašich logů, založte na GitHubu požadavek (New issue) s touto informací :"
+		},
+		"Unknown material, please contact the author ! {0}": {
+			"es": "Material desconocido, contacta con el autor  ! {0}",
+			"pt": "Material Thargoid, entre em contato com o autor! {0}",
+			"de": "Unbekanntes Material, bitte kontaktieren Sie den Autor ! {0}",
+			"fr": "Matériau inconnu, contactez l'auteur ! {0}",
+			"ru": "Неизвестный материал, пожалуйста свяжитесь с автором ! {0}",
+			"pl": "Nieznany materiał, skontaktuj się z autorem ! {0}",
+			"cs": "Neznámý materiál, kontaktujte autora aplikace ! {0}"
+		},
+		"Neither": {
+			"es": "Ninguno",
+			"pt": "Nenhum",
+			"de": "Weder noch",
+			"fr": "Autres",
+			"ru": "Никакой",
+			"pl": "Żadne",
+			"cs": "Žádný"
+		},
+		"Favorite": {
+			"es": "Favorito",
+			"pt": "Favorito",
+			"de": "Favoriten",
+			"fr": "Favoris",
+			"ru": "Избранные",
+			"pl": "Ulubione",
+			"cs": "Oblíbené"
+		},
+		"Ignored": {
+			"es": "Ignorado",
+			"pt": "Ignorado",
+			"de": "Ignorieren",
+			"fr": "Ignorés",
+			"ru": "Игнорируемые",
+			"pl": "Ignorowane",
+			"cs": "Ignorované"
+		},
+		"Craftable": {
+			"es": "Elaborable",
+			"pt": "Disponível para produção",
+			"de": "Baubare",
+			"fr": "Craftable",
+			"ru": "Доступны для изготовления",
+			"pl": "Możliwe do stworzenia",
+			"cs": "Vyrobitelné"
+		},
+		"Non Craftable": {
+			"es": "No Elaborable",
+			"pt": "Não disponível para produção",
+			"de": "Nicht baubare",
+			"fr": "Non Craftable",
+			"ru": "Недоступны для изготовления",
+			"pl": "Niemożliwe do stworzenia",
+			"cs": "Nevyrobitelné"
+		},
+		"Missing Commodities": {
+			"es": "Mercancía Perdida",
+			"pt": "Mercadoria Faltando",
+			"de": "Fehlende Handelswaren",
+			"fr": "Marchandise Manquantes",
+			"ru": "Не хватает товаров",
+			"pl": "Brakujące towary",
+			"cs": "Chybějící komodity"
+		},
+		"All": {
+			"es": "Todo",
+			"pt": "Tudo",
+			"de": "Alle",
+			"fr": "Tous",
+			"ru": "Все",
+			"pl": "Wszystko",
+			"cs": "Všechno"
+		},
+		"An error has been thrown by the application:": {
+			"es": "Se ha producido un error:",
+			"pt": "Ocorreu um erro:",
+			"de": "Ein Fehler ist aufgetreten:",
+			"fr": "Une erreur a été levée par l'application:",
+			"ru": "Приложением была выдана ошибка:",
+			"pl": "Błąd aplikacji:",
+			"cs": "Chyba aplikace:"
+		},
+		"Unrecoverable Error": {
+			"es": "Error Irrecuperable",
+			"pt": "Erro irrecuperável",
+			"de": "Fataler Fehler",
+			"fr": "Erreur Fatale",
+			"ru": "Неисправимая ошибка",
+			"pl": "Fatalny błąd",
+			"cs": "Fatální chyba"
+		},
+		"Close": {
+			"es": "Salir",
+			"pt": "Fechar",
+			"de": "Schließen",
+			"fr": "Fermer",
+			"ru": "Закрыть",
+			"pl": "Zamknij",
+			"cs": "Zavřít"
+		},
+		"Select a new log directory": {
+			"es": "Selecciona un nuevo directorio de logs",
+			"pt": "Selecione um novo diretório de log",
+			"de": "Wählen Sie ein neues Log Verzeichnis aus",
+			"fr": "Choisissez un nouveau répertoire de logs",
+			"ru": "Выбрать новую папку с log файлом",
+			"pl": "Wybierz nowy katalog z logami",
+			"cs": "Vyber nový adresář s logy hry"
+		},
+		"Couldn't find the log folder for elite, you'll have to specify it": {
+			"es": "No se pudo encontrar la carpeta de logs para Elite, tendrás que especificarla",
+			"pt": "Não foi possível encontrar a pasta de log para o elite, você precisará especificá-la",
+			"de": "Der Log Folder von Elite konnte nicht gefunden werden, bitte geben Sie ihn manuell an",
+			"fr": "Impossible de trouver le dossier des logs de Elite, vous devez le spécifier",
+			"ru": "Не удается найти папку с log файлом, вы должны выбрать ее самостоятельно",
+			"pl": "Nie znaleziono folderu z logami Elite, musisz go wybrać ręcznie",
+			"cs": "Nemůžu najít adresář s logy Elite, vyberte jej ručně:"
+		},
+		"Selected directory doesn't seem to contain any log file ; are you sure?": {
+			"es": "El directorio seleccionado no parece contener ningún log ; ¿Estás seguro?",
+			"pt": "O diretório selecionado parece não conter nenhum arquivo de log ; você tem certeza?",
+			"de": "Das gewählte Verzeichnis scheint keine Log Files zu enthalten ; Sind Sie sicher?",
+			"fr": "Le répertoire choisi ne semble pas contenir de fichier ; êtes vous sûr?",
+			"ru": "Выбранная папка не содержит log файл ; вы уверены?",
+			"pl": "Wygląda na to że wybrany katalog nie zawiera żadnego pliku z logami ; czy jesteś pewien?",
+			"cs": "Vybraný adresář zřejmě neobsahuje žádný log ; Jste si jistí?"
+		},
+		"Warning": {
+			"es": "Aviso",
+			"pt": "Atenção",
+			"de": "Warnung",
+			"fr": "Avertissement",
+			"ru": "Предупреждение",
+			"pl": "Ostrzeżenie",
+			"cs": "Varování"
+		},
+		"You did not select a log directory, EDEngineer won't be able to track changes. You can still use the app manually though.": {
+			"es": "No ha seleccionado un directorio de registro, EDEngineer no podrá realizar seguimiento de los cambios. Todavía puedes usar la aplicación manualmente.",
+			"pt": "Você não selecionou um diretório de registro, o EDEngineer não poderá acompanhar as alterações. Ainda assim, você ainda pode usar o aplicativo manualmente.",
+			"de": "Sie haben kein Log Verzeichnis gewählt, EDEngineer wird die Bestandsänderungen nicht aktualisieren können. Sie können die App jedoch manuell benutzen.",
+			"fr": "Vous n'avez pas choisi de dossier, EDEngineer ne sera pas capable de suivre vos changements. Il est cependant possible de continuer à utiliser l'application.",
+			"ru": "Вы не выбрали папку с log файлом, EDEngineer не сможет отслеживать изменения. Но вы все еще можете вносить изменения вручную.",
+			"pl": "Nie wybrałeś folderu z logami, EDEngineer nie będzie w stanie śledzić zmian. Nadal możesz korzystać z aplikacji manualnie.",
+			"cs": "Nezvolil jste adresář s logy hry, EDEngineer nebude schopen automaticky provádět změny. Stále však můžete používat aplikaci a ručně zadávat hodnoty."
+		},
+		"No folder in use ; click to change": {
+			"es": "Ninguna carpeta en uso ; haz clic para cambiar",
+			"pt": "Nenhuma pasta em uso ; clique para mudar",
+			"de": "Kein Verzeichnis in Verwendung ; Klicken Sie zum Ändern",
+			"fr": "Aucun répertoire ; cliquez ici pour changer",
+			"ru": "Папка не указана ; нажмите для изменения",
+			"pl": "Brak folderu w użyciu ; kliknij by zmienić",
+			"cs": "Nepoužívá se žádná složka ; klikni pro změnu"
+		},
+		"Favorite Blueprint Ready": {
+			"es": "Receta lista",
+			"pt": "Diagrama favorito pronto",
+			"de": "Bauplan fertig",
+			"fr": "Recette Prête",
+			"ru": "Чертеж готов",
+			"pl": "Ulubiony schemat gotowy",
+			"cs": "Oblíbený plánek připraven"
+		},
+		"Select Language": {
+			"es": "Cambiar idioma",
+			"pt": "Selecionar Idioma",
+			"de": "Sprache wählen",
+			"fr": "Choisissez la langue",
+			"ru": "Выбрать язык",
+			"pl": "Wybierz język",
+			"cs": "Vyber jazyk"
+		},
+		"Surface prospecting": {
+			"es": "Prospección de superficie",
+			"pt": "Prospecção de superfície",
+			"de": "Oberflächenabbau (SRV)",
+			"fr": "Prospection de surface",
+			"ru": "Поверхность планет",
+			"pl": "Górnictwo odkrywkowe (SRV)",
+			"cs": "Povrchový průzkum (SRV)"
+		},
+		"Mining": {
+			"es": "Minería",
+			"pt": "Mineração",
+			"de": "Abbau",
+			"fr": "Minage",
+			"ru": "Добыча",
+			"pl": "Górnictwo",
+			"cs": "Težba"
+		},
+		"Mission reward": {
+			"es": "Recompensa de misiones",
+			"pt": "Recompensa da missão",
+			"de": "Missions-Belohnungen",
+			"fr": "Récompense de mission",
+			"ru": "Награда за миссию",
+			"pl": "Nagroda za ukończenie misji",
+			"cs": "Odměna z mise"
+		},
+		"Mining (ice rings)": {
+			"es": "Minería (anillos helados)",
+			"pt": "Mineração (anéis de gelo)",
+			"de": "Abbau (Eis Ringe)",
+			"fr": "Minage (anneaux glacés)",
+			"ru": "Добыча (ледяные кольца)",
+			"pl": "Górnictwo (pierścienie: lodowe)",
+			"cs": "Těžba (ledové prstence)"
+		},
+		"Ship salvage (transport ships)": {
+			"es": "Rescate de naves (naves de transporte)",
+			"pt": "Destroços de naves (naves de transporte)",
+			"de": "Bergungsgut Schiffswrack (Transportschiffe)",
+			"fr": "Restes de vaisseaux détruits (Type: Transport)",
+			"ru": "Уничтожение корабля (транспортные)",
+			"pl": "Wrak statku (statki: transportowe)",
+			"cs": "Vrak lodě (transportní lodě)"
+		},
+		"Signal source (high security)": {
+			"es": "Señales (seguridad alta)",
+			"pt": "Fonte de sinal (segurança alta)",
+			"de": "Signalquelle (Hohe Sicherheit)",
+			"fr": "Source de Signal (Système : Haute Sécurité)",
+			"ru": "Источник сигнала (высокий уровень безопасности)",
+			"pl": "Źródła sygnału (wysokie bezpieczeństwo)",
+			"cs": "Zdroj signálu (vysoká bezpečnost - HIGH SEC.)"
+		},
+		"Surface POI": {
+			"es": "Puntos de interés de superficie",
+			"pt": "Pontos de interesse de superfície",
+			"de": "Planetenoberfläche POI",
+			"fr": "POI en Surface",
+			"ru": "Точки интереса на планетах",
+			"pl": "Planetarne POI",
+			"cs": "Planetární POI"
+		},
+		"Signal source": {
+			"es": "Señales",
+			"pt": "Fonte de sinal",
+			"de": "Signalquelle",
+			"fr": "Source de Signal",
+			"ru": "Источник сигнала",
+			"pl": "Źrodła sygnału",
+			"cs": "Zdroj signálu"
+		},
+		"Ship salvage (combat ships)": {
+			"es": "Rescate de naves (naves de combate)",
+			"pt": "Destroços de nave (naves de combate)",
+			"de": "Bergungsgut Schiffswrack (Kampfschiffe)",
+			"fr": "Restes de vaisseaux détruits (Type: Combat)",
+			"ru": "Уничтожение корабля (боевые)",
+			"pl": "Wrak statku (statki: bojowe)",
+			"cs": "Vrak lodě (bojové lodě)"
+		},
+		"Signal source (anarchy)": {
+			"es": "Señales (anarquía)",
+			"pt": "Fonte de sinal (anarquia)",
+			"de": "Signalquelle (Anarchie)",
+			"fr": "Source de signal (Système : Anarchique)",
+			"ru": "Источник сигнала (анархия)",
+			"pl": "Źródła sygnału (anarchia)",
+			"cs": "Zdroj signálu (anarchy)"
+		},
+		"Signal source (low security)": {
+			"es": "Señales (seguridad baja)",
+			"pt": "Fonte de sinal (baixa segurança)",
+			"de": "Signalquelle (Niedrige Sicherheit)",
+			"fr": "Source de signal (Système : Basse Sécuritée)",
+			"ru": "Источник сигнала (низкий уровень безопасности)",
+			"pl": "Źródła sygnału (niskie bezpieczeństwo)",
+			"cs": "Zdroj signálu (nízká bezpečnost - LOW SEC.)"
+		},
+		"Signal source (High grade emissions)": {
+			"es": "Señales (alta calidad)",
+			"pt": "Fonte de sinal (transmissões de alto grau)",
+			"de": "Signalquelle (Hochgradige Emissionen)",
+			"fr": "Source de signal (Emissions de haute qualitée)",
+			"ru": "Источник сигнала (высокоуровневое излучение)",
+			"pl": "Źródła sygnału (High grade emissions)",
+			"cs": "Zdroj signálu (High grade emissions)"
+		},
+		"Ship salvage (military & authority ships)": {
+			"es": "Rescate de naves (naves militares y de la autoridad)",
+			"pt": "Destroços de naves (naves militades e de autoridades)",
+			"de": "Bergungsgut Schiffswrack (Militär und Sicherheitsdienst)",
+			"fr": "Restes de vaisseaux détruits (Type: Militaire & Autorité Système)",
+			"ru": "Уничтожение корабля (военные и силы правопорядка)",
+			"pl": "Wrak statku (statki: wojskowe i policyjne)",
+			"cs": "Vrak lodi (vojenské a policejní lodě - mil.+auth.)"
+		},
+		"Destroyed Unknown Artefact": {
+			"es": "Destrucción de Artefacto Desconocido",
+			"pt": "Destruição de artefato desconhecido",
+			"de": "Zerstörtes unbekanntes Artefakt",
+			"fr": "Artéfact Inconnu Détruit / Fragment Inconnu",
+			"ru": "Уничтоженный Неизвестный Артефакт",
+			"pl": "Zniszczenie Nieznanego Artefaktu (UA)",
+			"cs": "Zničený neznámý artefakt (UA)"
+		},
+		"Ship scanning (combat ships)": {
+			"es": "Escaneo de naves (naves de combate)",
+			"pt": "Escaneamento de naves (naves de combate)",
+			"de": "Schiff Scan (Kampfschiffe)",
+			"fr": "Scan de vaisseaux de Combat",
+			"ru": "Сканирование корабля (боевые)",
+			"pl": "Skanowanie statków (typ: bojowe)",
+			"cs": "Skenování lodě (bojové lodě)"
+		},
+		"Deep space data beacon": {
+			"es": "Baliza de datos en espacio profundo",
+			"pt": "Sinalizador de dados em espaço profundo",
+			"de": "Privatdaten-Signal (deep space)",
+			"fr": "Balise de donnée (espace)",
+			"ru": "Данные маяка (дальний космос)",
+			"pl": "Skanowanie POI w przestrzeni kosmicznej",
+			"cs": "Skenování Beaconu (deep space)"
+		},
+		"Ship scanning (transport ships)": {
+			"es": "Escaneo de naves (naves de transporte)",
+			"pt": "Escaneamento de naves (naves de transporte)",
+			"de": "Schiff Scan (Transportschiffe)",
+			"fr": "Scan de vaisseaux (Type : Transport)",
+			"ru": "Сканирование корабля (транспортные)",
+			"pl": "Skanowanie statków (typ: transportowe)",
+			"cs": "Skenování lodě (transportní lodě)"
+		},
+		"High wake scanning": {
+			"es": "Escaneo de estelas de salto",
+			"pt": "Escaneamento de rastro alto",
+			"de": "Sogwolkenscan (Hohe Energie)",
+			"fr": "scan de sillages à haute energie",
+			"ru": "Сканирование высокочастотных следов FSD",
+			"pl": "Skanowanie High Wake",
+			"cs": "Skenování High Wake"
+		},
+		"Surface data point": {
+			"es": "Punto de datos de superficie",
+			"pt": "Ponto de dados de suferfície",
+			"de": "POI-Datenpunkt",
+			"fr": "POI",
+			"ru": "Наземные точки данных",
+			"pl": "Skanowanie planetarnego POI",
+			"cs": "Skenování POI na povrchu planety"
+		},
+		"Ship scanning": {
+			"es": "Escaneo de naves",
+			"pt": "Escaneamento de naves",
+			"de": "Schiff Scan",
+			"fr": "Scan de vaisseaux",
+			"ru": "Сканирование корабля",
+			"pl": "Skanowanie statków",
+			"cs": "Skenování lodě"
+		},
+		"Markets": {
+			"es": "Mercados",
+			"pt": "Mercados",
+			"de": "Märkte",
+			"fr": "Marchés",
+			"ru": "Рынки",
+			"pl": "Rynki",
+			"cs": "Obchody"
+		},
+		"Markets near Akhenaten (High Tech/Refinery)": {
+			"es": "Mercados cerca de Akhenaten (Alta Tecnología/Refinería)",
+			"pt": "Mercados perto de Akhenaten (Alta Tecnología/Refinaria)",
+			"de": "Märkte nahe Akhenaten (Hightech/Raffinerie)",
+			"fr": "Marchés près de Akhenaten (Haute Technologie/Raffinerie)",
+			"ru": "Рынки около Akhenaten (Высокотехнологичные/Перерабатывающие)",
+			"pl": "Rynki w pobliżu systemu Akhenaten (High Tech/Refinery)",
+			"cs": "Obchody v blízkosti Akhenaten (High Tech/Refinery)"
+		},
+		"Markets near Stafkarl (Industrial/Refinery)": {
+			"es": "Mercados cerca de Stafkarl (Industrial/Refinería)",
+			"pt": "Mercados perto de Stafkarl (Industrial/Refinaria)",
+			"de": "Märkte nahe Stafkarl (Industrie/Raffinerie)",
+			"fr": "Marchés près de Stafkarl (Industriel/Raffinerie)",
+			"ru": "Рынки около Stafkarl (Промышленные/Перерабатывающие)",
+			"pl": "Rynki w pobliżu systemu Stafkarl (Industrial/Refinery)",
+			"cs": "Obchody v blízkosti Stafkarl (Industrial/Refinery)"
+		},
+		"Markets near Run (Industrial/Refinery)": {
+			"es": "Mercados cerca de Run (Industrial/Refinería)",
+			"pt": "Mercados perto de Run (Industrial/Refinaria)",
+			"de": "Märkte nahe Run (Industrie/Raffinerie)",
+			"fr": "Marchés près de Run (Industriel/Raffinerie)",
+			"ru": "Рынки около Run (Промышленные/Перерабатывающие)",
+			"pl": "Rynki w pobliżu systemu Run (Industrial/Refinery)",
+			"cs": "Obchody v blízkosti Run (Industrial/Refinery)"
+		},
+		"Markets near Lei Jing (Industrial/Refinery)": {
+			"es": "Mercados cerca de Lei Jing (Industrial/Refinería)",
+			"pt": "Mercados perto de Lei Jing (Industrial/Refinaria)",
+			"de": "Märkte nahe Lei Jing (Industrie/Raffinerie)",
+			"fr": "Marchés près de Lei Jing (Industriel/Raffinerie)",
+			"ru": "Рынки около Lei Jing (Промышленные/Перерабатывающие)",
+			"pl": "Rynki w pobliżu systemu Lei Jing (Industrial/Refinery)",
+			"cs": "Obchody v blízkosti Lei Jing (Industrial/Refinery)"
+		},
+		"Markets near Myrbat (Industrial/Refinery)": {
+			"es": "Mercados cerca de Myrbat (Industrial/Refinería)",
+			"pt": "Mercados perto de Myrbat (Industrial/Refinaria)",
+			"de": "Märkte nahe Myrbat (Industrie/Raffinerie)",
+			"fr": "Marchés près de Myrbat (Industriel/Raffinerie)",
+			"ru": "Рынки около Myrbat (Промышленные/Перерабатывающие)",
+			"pl": "Rynki w pobliżu systemu Myrbat (Industrial/Refinery)",
+			"cs": "Obchody v blízkosti Myrbat (Industrial/Refinery)"
+		},
+		"Markets near 70 Tauri (Industrial/Extraction)": {
+			"es": "Mercados cerca de 70 Tauri (Industrial/Extracción)",
+			"pt": "Mercados perto de 70 Tauri (Industrial/Extração)",
+			"de": "Märkte nahe 70 Tauri (Industrie/Abbau)",
+			"fr": "Marchés près de 70 Tauri (Industriel/Extraction)",
+			"ru": "Рынки около 70 Tauri (Промышленные/Добывающие)",
+			"pl": "Rynki w pobliżu systemu 70 Tauri (Industrial/Extraction)",
+			"cs": "Obchody v blízkosti 70 Tauri (Industrial/Extraction)"
+		},
+		"Markets near Leesti (Industrial/Refinery)": {
+			"es": "Mercados cerca de Leesti (Industrial/Refinería)",
+			"pt": "Mercados perto de Leesti (Industrial/Refinaria)",
+			"de": "Märkte nahe Leesti (Industrie/Raffinerie)",
+			"fr": "Marchés près de Leesti (Industriel/Raffinerie)",
+			"ru": "Рынки около Leesti (Промышленные/Перерабатывающие)",
+			"pl": "Rynki w pobliżu systemu Leesti (Industrial/Refinery)",
+			"cs": "Obchody v blízkosti Leesti (Industrial/Refinery)"
+		},
+		"Markets near Lakota (Industrial/Extraction)": {
+			"es": "Mercados cerca de Lakota (Industrial/Extracción)",
+			"pt": "Mercados perto de Lakota (Industrial/Extração)",
+			"de": "Märkte nahe Lakota (Industrie/Abbau)",
+			"fr": "Marchés près de Lakota (Industriel/Extraction)",
+			"ru": "Рынки около Lakota (Промышленные/Добывающие)",
+			"pl": "Rynki w pobliżu systemu Lakota (Industrial/Extraction)",
+			"cs": "Obchody v blízkosti Lakota (Industrial/Extraction)"
+		},
+		"Markets near Cilbien Zu (Industrial/Extraction)": {
+			"es": "Mercados cerca de Cilbien Zu (Industrial/Extracción)",
+			"pt": "Mercados perto de Cilbien Zu (Industrial/Extração)",
+			"de": "Märkte nahe Cilbien Zu (Industrie/Abbau)",
+			"fr": "Marchés près de Cilbien Zu (Industriel/Extraction)",
+			"ru": "Рынки около Cilbien Zu (Промышленные/Добывающие)",
+			"pl": "Rynki w pobliżu systemu Cilbien Zu (Industrial/Extraction)",
+			"cs": "Obchody v blízkosti Cilbien Zu (Industrial/Extraction)"
+		},
+		"Markets near Heget (Industrial/Extraction)": {
+			"es": "Mercados cerca de Heget (Industrial/Extracción)",
+			"pt": "Mercados perto de Heget (Industrial/Extração)",
+			"de": "Märkte nahe Heget (Industrie/Abbau)",
+			"fr": "Marchés près de Heget (Industriel/Extraction)",
+			"ru": "Рынки около Heget (Промышленные/Добывающие)",
+			"pl": "Rynki w pobliżu systemu Heget (Industrial/Extraction)",
+			"cs": "Obchody v blízkosti Heget (Industrial/Extraction)"
+		},
+		"Markets near Eurybia (Extraction/Refinery)": {
+			"es": "Mercados cerca de Eurybia (Extracción/Refinería)",
+			"pt": "Mercados perto de Eurybia (Extracción/Refinaria)",
+			"de": "Märkte nahe Eurybia (Abbau/Raffinerie)",
+			"fr": "Marchés près de Eurybia (Extraction/Raffinerie)",
+			"ru": "Рынки около Eurybia (Добывающие/Перерабатывающие)",
+			"pl": "Rynki w pobliżu systemu Eurybia (Extraction/Refinery)",
+			"cs": "Obchody v blízkosti Eurybia (Extraction/Refinery)"
+		},
+		"Ingredient not used in any blueprint!": {
+			"es": "Elemento no usado en ninguna receta!",
+			"pt": "Ingrediente não utilizado em nenhum Diagrama",
+			"de": "Bestandteil in keinem bekannten Bauplan!",
+			"fr": "Materiau utilisé dans aucune recette!",
+			"ru": "Ингредиент не используется в чертежах!",
+			"pl": "Składnik nie jest używany w żadnym schemacie!",
+			"cs": "Ingredience není použita v žádném plánku!"
+		},
+		"+100% Fuel Efficiency": {
+			"es": "+100% Eficiencia de combustible",
+			"pt": "+100% Eficiência do combustível",
+			"de": "+100% Bonus Treibstoffeffizienz",
+			"fr": "+100% Efficacité du carburant",
+			"ru": "+100% к эффективности топлива",
+			"pl": "+100% efektywności paliwa",
+			"cs": "+100% efektivita paliva"
+		},
+		"+100% Hull Strength": {
+			"es": "+100% Resistencia de casco",
+			"pt": "+100% Força do casco",
+			"de": "+100% Bonus Rumpfstärke",
+			"fr": "+100% bonus coque",
+			"ru": "+100% к прочности корпуса",
+			"pl": "+100% wzmocnienie kadłuba",
+			"cs": "+100% k síle trupu"
+		},
+		"+100% Jump Range": {
+			"es": "+100% Distancia de salto",
+			"pt": "+100% Alcance do salto",
+			"de": "+100% Bonus Entfernung",
+			"fr": "+100% portée de saut",
+			"ru": "+100% к дальности прыжка",
+			"pl": "+100% zasięgu skoku",
+			"cs": "+100% k maximálnímu skoku"
+		},
+		"+100% Repair Speed": {
+			"es": "+100% Velocidad de reparación",
+			"pt": "+100% Velocidade de reparo",
+			"de": "+100% Bonus Reparaturgeschwindigkeit",
+			"fr": "+100% vitesse de réparation",
+			"ru": "+100% к скорости ремонта",
+			"pl": "+100% szybkości napraw",
+			"cs": "+100% k rychlosti opravování"
+		},
+		"+15% Damage Boost": {
+			"es": "+15% al daño",
+			"pt": "+15% Aumento de dano",
+			"de": "+15% Bonus Schaden",
+			"fr": "+15% dégâts",
+			"ru": "+15% к урону",
+			"pl": "+15% dodatkowych obrażeń",
+			"cs": "+15% k poškození touto zbraní"
+		},
+		"+200% Fuel Efficiency": {
+			"es": "+200% Eficiencia de combustible",
+			"pt": "+200% Eficiência do combustível",
+			"de": "+200% Bonus Treibstoffeffizienz",
+			"fr": "+200% Efficacité du carburant",
+			"ru": "+200% к эффективности топлива",
+			"pl": "+200% efektywności paliwa",
+			"cs": "+200% efektivita paliva"
+		},
+		"+25% Jump Range": {
+			"es": "+25% Distancia de salto",
+			"pt": "+25% Alcance do salto",
+			"de": "+25% Bonus Entfernung",
+			"fr": "+25% portée de saut",
+			"ru": "+25% к дальности прыжка",
+			"pl": "+25% zasięgu skoku",
+			"cs": "+25% k maximálnímu skoku"
+		},
+		"+30% Damage Boost": {
+			"es": "+30% al daño",
+			"pt": "+30% Aumento de dano",
+			"de": "+30% Bonus Schaden",
+			"fr": "+30% dégâts",
+			"ru": "+30% к урону",
+			"pl": "+30% dodatkowych obrażeń",
+			"cs": "+30% k poškození touto zbraní"
+		},
+		"+50% Hull Strength": {
+			"es": "+50% Resistencia de casco",
+			"pt": "+50% Força do casco",
+			"de": "+50% Bonus Rumpfstärke",
+			"fr": "+50% bonus coque",
+			"ru": "+50% к прочности корпуса",
+			"pl": "+50% wzmocnienie kadłuba",
+			"cs": "+50% k síle trupu"
+		},
+		"+50% Jump Range": {
+			"es": "+50% Distancia de salto",
+			"pt": "+50% Alcance do salto",
+			"de": "+50% Bonus Entfernung",
+			"fr": "+50% portée de saut",
+			"ru": "+50% к дальности прыжка",
+			"pl": "+50% zasięgu skoku",
+			"cs": "+50% k maximálnímu skoku"
+		},
+		"+50% Repair Speed": {
+			"es": "+50% Velocidad de reparación",
+			"pt": "+50% Velocidade de reparo",
+			"de": "+50% Bonus Reparaturgeschwindigkeit",
+			"fr": "+50% vitesse de réparation",
+			"ru": "+50% к скорости ремонта",
+			"pl": "+50% szybkości napraw",
+			"cs": "+50% k rychlosti opravování"
+		},
+		"AFM Refill": {
+			"es": "Recarga de UAM",
+			"pt": "Recarga de UMT",
+			"de": "AFW-Auffrischung",
+			"fr": "Unité de maintenance rechargée",
+			"ru": "Снабжение АПР",
+			"pl": "AFM Refill",
+			"cs": "AFM Refill"
+		},
+		"Explosive Munitions": {
+			"es": "Munición explosiva",
+			"pt": "Munição explosiva",
+			"de": "Explosivmunition",
+			"fr": "Munitions Explosives",
+			"ru": "Взрывчатые боеприпасы",
+			"pl": "Explosive Munitions",
+			"cs": "Explosive Munitions"
+		},
+		"FSD Injection": {
+			"es": "Inyección del MDD",
+			"pt": "Interditores de MDD",
+			"de": "FSA-Einspeisung",
+			"fr": "Injection FSD",
+			"ru": "Вброс в FSD",
+			"pl": "FSD Injection",
+			"cs": "FSD Injection"
+		},
+		"High Velocity Munitions": {
+			"es": "Munición de alta velocidad",
+			"pt": "Munições de alta velocidade",
+			"de": "Hochgeschwindigkeitsmunition",
+			"fr": "Munitions à Haute Vélocité",
+			"ru": "Высокоскоростные боеприпасы",
+			"pl": "High Velocity Munitions",
+			"cs": "High Velocity Munitions"
+		},
+		"Large Calibre Munitions": {
+			"es": "Munición de gran calibre",
+			"pt": "Munições de grande calibre",
+			"de": "Großkalibrige Munition",
+			"fr": "Munitions de gros Calibre",
+			"ru": "Крупнокалиберные боеприпасы",
+			"pl": "Large Calibre Munitions",
+			"cs": "Large Calibre Munitions"
+		},
+		"None": {
+			"es": "Ninguna",
+			"pt": "Nenhum",
+			"de": "Kein Bonus",
+			"fr": "aucun",
+			"ru": "Нет",
+			"pl": "Nic",
+			"cs": "Nic"
+		},
+		"Plasma Munitions": {
+			"es": "Munición de plasma",
+			"pt": "Munição de Plasma",
+			"de": "Plasmamunition",
+			"fr": "Munitions plasma",
+			"ru": "Плазменные боеприпасы",
+			"pl": "Plasma Munitions",
+			"cs": "Plasma Munitions"
+		},
+		"Small Calibre Munitions": {
+			"es": "Munición de pequeño calibre",
+			"pt": "Munição de Pequeno Calibre",
+			"de": "Kleinkalibrige Munition",
+			"fr": "Munitions de petit calibre",
+			"ru": "Мелкокалиберные боеприпасы",
+			"pl": "Small Calibre Munitions",
+			"cs": "Small Calibre Munitions"
+		},
+		"SRV Ammo Restock": {
+			"es": "Suministro de munición de VRS",
+			"pt": "Munição do VRS",
+			"de": "SRV-Munitionsnachladung",
+			"fr": "Munitions SRV",
+			"ru": "Боеприпасы для ТРП",
+			"pl": "Odnowienie amunicji SRV",
+			"cs": "Doplnění munice SRV"
+		},
+		"SRV Refuel": {
+			"es": "Repostaje del VRS",
+			"pt": "Reabastecimento de VRS",
+			"de": "SRV-Auftankung",
+			"fr": "Carburant SRV",
+			"ru": "Заправка ТРП",
+			"pl": "Tankowanie SRV",
+			"cs": "Doplnění paliva SRV"
+		},
+		"SRV Repair": {
+			"es": "Reparación del VRS",
+			"pt": "Reparo de VRS",
+			"de": "SRV-Reparaturen",
+			"fr": "Réparation SRV",
+			"ru": "Ремонт ТРП",
+			"pl": "Naprawa SRV",
+			"cs": "Oprava SRV"
+		},
+		"@Synthesis": {
+			"es": "@Síntesis",
+			"pt": "@Sínteses",
+			"de": "@Synthese",
+			"fr": "@Synthèse",
+			"ru": "@Синтез",
+			"pl": "@Synteza",
+			"cs": "@Syntéza"
+		},
+		"Launch Local API": {
+			"es": "Iniciar el servidor local de API",
+			"pt": "Inicie o servidor da API local",
+			"de": "Lokalen API Server starten",
+			"fr": "Lancer le serveur API local",
+			"ru": "Запустить локальный API сервер",
+			"pl": "Uruchom lokalne API",
+			"cs": "Start lokálního API serveru"
+		},
+		"Select the port for the local API server": {
+			"es": "Selecciona el puerto para el servidor local de API",
+			"pt": "Selecione a porta para o servidor da API local",
+			"de": "Wählen Sie den Port für den lokalen API Server",
+			"fr": "Sélectionnez le port pour le server API local",
+			"ru": "Выберите порт для локального API сервера",
+			"pl": "Wybierz port dla lokalnego serwera API",
+			"cs": "Vyber port lokálního API serveru"
+		},
+		"Auto run server on EDEngineer startup with this port? (if not ticked, the server will stop when you unlock/lock the window)": {
+			"es": "¿Deseas usar este puerto al ejecutar el servidor de EDEngineer? (si no está seleccionada esta opción el servidor podría detenerse cuando se bloquee o desbloquee la ventana)",
+			"pt": "Servidor de execução automática no EDEngineer, iniciar com esta porta? (se não estiver assinalado, o servidor pode parar quando a janela estiver bloqueada ou desbloqueada)",
+			"de": "Soll der Server beim Starten von EDEngineer automatisch mit diesem Port starten? (Wenn nicht selektiert, wird der Server beim freigeben/fixieren des Fensters stoppen)",
+			"fr": "Lancer automatiquement le serveur au démarrage avec ce port ? (sinon, le serveur s'arrêtera lorsque vous changerez le mode de la fenêtre (Bloquer/arrière plan)')",
+			"ru": "Запускать сервер с этим портом автоматически при запуске EDEngineer? (если этот параметр не выбран, сервер остановится, когда вы разблокируете/заблокируете окно)",
+			"pl": "Automatycznie uruchamiaj serwer podczas włączania EDEngineer na tym porcie? (jeżeli nie zaznaczone, serwer zostanie zatrzymany kiedy odblokujesz/zablokujesz okno)",
+			"cs": "Automaticky špouštět server s tímto portem při zapnutí EDEngineera? (pokud není zašrtnuto, server se zastaví při odemčení/zamčení okna)"
+		},
+		"Shopping List": {
+			"es": "Lista de la compra",
+			"pt": "Lista de compras",
+			"de": "Einkaufsliste",
+			"fr": "Liste de courses",
+			"ru": "Список покупок",
+			"pl": "Lista zakupów",
+			"cs": "Nákupní seznam"
+		},
+		"Needed for Marco Qwent (25)": {
+			"es": "Necesario para Marco Qwent (25)",
+			"pt": "Necessário para Marco Qwent (25)",
+			"de": "Benötigt für Marco Qwent (25)",
+			"fr": "Nécessaire pour Marco Qwent (25)",
+			"ru": "Необходимо для Marco Qwent (25)",
+			"pl": "Potrzebne dla Marco Qwent (25)",
+			"cs": "Potřebné pro Marco Qwenta (25)"
+		},
+		"Needed for Ram Tah (50)": {
+			"es": "Necesario para Ram Tah (50)",
+			"pt": "Necessário para Ram Tah (50)",
+			"de": "Benötigt für Ram Tah (50)",
+			"fr": "Nécessaire pour Ram Tah (50)",
+			"ru": "Необходимо для Ram Tah (50)",
+			"pl": "Potrzebne dla Ram Tah (50)",
+			"cs": "Potřebné pro Ram Taha (50)"
+		},
+		"Needed for Professor Palin (25)": {
+			"es": "Necesario para Professor Palin (25)",
+			"pt": "Necessário para o Professor Palin (25)",
+			"de": "Benötigt für Professor Palin (25)",
+			"fr": "Nécessaire pour Professor Palin (25)",
+			"ru": "Необходимо для Professor Palin (25)",
+			"pl": "Potrzebne dla Professor Palin (25)",
+			"cs": "Potřebné pro profesora Palina (25)"
+		},
+		"Needed for Tiana Fortune (50)": {
+			"es": "Necesario para Tiana Fortune (50)",
+			"pt": "Necessário para Tiana Fortune (50)",
+			"de": "Benötigt für Tiana Fortune (50)",
+			"fr": "Nécessaire pour Tiana Fortune (50)",
+			"ru": "Необходимо для Tiana Fortune (50)",
+			"pl": "Potrzebne dla Tiana Fortune (50)",
+			"cs": "Potřebné pro Tianu Fortune (50)"
+		},
+		"Needed for The Sarge (50)": {
+			"es": "Necesario para The Sarge (50)",
+			"pt": "Necessário para The Sarge (50)",
+			"de": "Benötigt für The Sarge (50)",
+			"fr": "Nécessaire pour The Sarge (50)",
+			"ru": "Необходимо для The Sarge (50)",
+			"pl": "Potrzebne dla The Sarge (50)",
+			"cs": "Potřebné pro The Sarge (50)"
+		},
+		"Needed for Bill Turner (50)": {
+			"es": "Necesario para Bill Turner (50)",
+			"pt": "Necessário para Bill Turner (50)",
+			"de": "Benötigt für Bill Turner (50)",
+			"fr": "Nécessaire pour Bill Turner (50)",
+			"ru": "Необходимо для Bill Turner (50)",
+			"pl": "Potrzebne dla Bill Turner (50)",
+			"cs": "Potřebné pro Billa Turnera (50)"
+		},
+		"Show information about resources?": {
+			"es": "Mostrar información sobre recursos?",
+			"pt": "Mostrar informação sobre recursos?",
+			"de": "Informationen über Ressourcen anzeigen?",
+			"fr": "Afficher les informations sur les ressources ?",
+			"ru": "Показывать информацию о ресурсах?",
+			"pl": "Pokaż dodatkowe informacje o komponentach",
+			"cs": "Zobrazit informace o tom, kde lze získat data/materiály?"
+		},
+		"Count": {
+			"es": "Número",
+			"pt": "Número",
+			"de": "Anzahl",
+			"fr": "Nombre",
+			"ru": "Количество",
+			"pl": "Ilość",
+			"cs": "Počet"
+		},
+		"Thargoid Ship Signature": {
+			"es": "Firma Térmica de Nave Thargoide",
+			"pt": "Assinatura de nave desconhecida",
+			"de": "Unbekannte Schiffsignatur",
+			"fr": "Signature de Vaisseau Thargoid",
+			"ru": "Сигнатура таргоидского корабля",
+			"pl": "Thargoid Ship Signature",
+			"cs": "Thargoid Ship Signature"
+		},
+		"Thargoid Wake Data": {
+			"es": "Datos de Estela Thargoide",
+			"pt": "Dados de Rastro Desconhecido",
+			"de": "Unbekannte Sogwolke",
+			"fr": "Donnée de Sillage Thargoid",
+			"ru": "Данные следа таргоидского корабля",
+			"pl": "Thargoid Wake Data",
+			"cs": "Thargoid Wake Data"
+		},
+		"Check all filters": {
+			"es": "Marcar todos los filtros",
+			"pt": "Marcar todos os filtros",
+			"de": "Alle Filter anwählen",
+			"fr": "Tous les filtres",
+			"ru": "Включить все фильтры",
+			"pl": "Zaznacz wszystkie filtry",
+			"cs": "Vyber všechny filtry"
+		},
+		"Uncheck all filters": {
+			"es": "Descarmar todos los filtros",
+			"pt": "Desmarcar todos os filtros",
+			"de": "Alle Filter abwählen",
+			"fr": "Aucun filtre",
+			"ru": "Отключить все фильтры",
+			"pl": "Odznacz wszystkie filtry",
+			"cs": "Zruš všechny filtry"
+		},
+		"Rarity": {
+			"es": "Rareza",
+			"pt": "Raridade",
+			"de": "Seltenheit",
+			"fr": "Rareté",
+			"ru": "Редкость",
+			"pl": "Rzadkość",
+			"cs": "Vzácnost"
+		},
+		"Kind": {
+			"es": "Tipo",
+			"pt": "Tipo",
+			"de": "Art",
+			"fr": "Type",
+			"ru": "Вид",
+			"pl": "Rodzaj",
+			"cs": "Druh"
+		},
+		"Search": {
+			"es": "Buscar",
+			"pt": "Buscar",
+			"de": "Suche",
+			"fr": "Recherche",
+			"ru": "Поиск",
+			"pl": "Szukaj",
+			"cs": "Hledat"
+		},
+		"Apply": {
+			"es": "Aplicar",
+			"pt": "Aplicar",
+			"de": "Anwenden",
+			"fr": "Appliquer",
+			"ru": "Применить",
+			"pl": "Zastosuj",
+			"cs": "Použít"
+		},
+		"Rare": {
+			"es": "Raro",
+			"pt": "Raro",
+			"de": "selten",
+			"fr": "Rare",
+			"ru": "Редкие",
+			"pl": "Rzadka",
+			"cs": "Rare (vzácný)"
+		},
+		"Very Rare": {
+			"es": "Muy Raro",
+			"pt": "Muito raro",
+			"de": "sehr selten",
+			"fr": "Très rare",
+			"ru": "Очень редкие",
+			"pl": "Bardzo rzadka",
+			"cs": "Very Rare (velmi vzácný)"
+		},
+		"Very Common": {
+			"es": "Muy Común",
+			"pt": "Muito comum",
+			"de": "sehr häufig",
+			"fr": "Très commun",
+			"ru": "Очень распространенные",
+			"pl": "Bardzo pospolita",
+			"cs": "Very Common (velmi běžný)"
+		},
+		"Common": {
+			"es": "Común",
+			"pt": "Comum",
+			"de": "häufig",
+			"fr": "Commun",
+			"ru": "Распространенные",
+			"pl": "Pospolita",
+			"cs": "Common (běžný)"
+		},
+		"Standard": {
+			"es": "estándar",
+			"pt": "Padrão",
+			"de": "Standard",
+			"fr": "Standard",
+			"ru": "Обычные",
+			"pl": "Standardowa",
+			"cs": "Standard"
+		},
+		"Multiple Blueprints Ready": {
+			"es": "Múltiples Planos Listos",
+			"pt": "Múltiplos Diagramas Prontos",
+			"de": "verschiedene Baupläne fertig",
+			"fr": "Multiple Plans de Fabrications Disponibles",
+			"ru": "Готово несколько чертежей",
+			"pl": "Wiele schematów gotowych do stworzenia",
+			"cs": "Několik plánků je připraveno"
+		},
+		"{0} blueprints are available to craft!": {
+			"es": "¡{0} planos están disponibles para crear!",
+			"pt": "{0} diagramas estão disponiveis para produção!",
+			"de": "{0} Baupläne stehen zur Herstellung zur Verfügung!",
+			"fr": "{0} plans de fabrications sont disponibles pour la production",
+			"ru": "Можно создать {0} чертежей!",
+			"pl": "Można stworzyć {0} schematów!",
+			"cs": "{0} plánků je připraveno k výrobě!"
+		},
+		"Sensors": {
+			"es": "Sensores",
+			"pt": "Sensores",
+			"de": "Sensoren",
+			"fr": "Capteurs",
+			"ru": "Сенсоры",
+			"pl": "Sensors",
+			"cs": "Sensors"
+		},
+		"Surface Scanner": {
+			"es": "Escáner de Superficie",
+			"pt": "Scanners de superfície",
+			"de": "Oberflächen-Scanner",
+			"fr": "Scanner de Surface",
+			"ru": "Сканер поверхности",
+			"pl": "Surface Scanner",
+			"cs": "Surface Scanner"
+		},
+		"Wake Scanner": {
+			"es": "Escáner de Estela",
+			"pt": "Scanner de rastro",
+			"de": "Sogwolkenscanner",
+			"fr": "Scanner de Sillage",
+			"ru": "Сканер следа",
+			"pl": "Wake Scanner",
+			"cs": "Wake Scanner"
+		},
+		"Last update: ": {
+			"es": "Última actualización: ",
+			"pt": "Última atualização",
+			"de": "letzte Aktualisierung",
+			"fr": "Dernière mise à jour: ",
+			"ru": "Последнее обновление: ",
+			"pl": "Ostatnia aktualizacja:",
+			"cs": "Poslední aktualizace:"
+		},
+		"Silent Launch": {
+			"es": "Iniciar Minimizado",
+			"pt": "Iniciar Minimizado",
+			"de": "Start minimiert",
+			"fr": "Démarrage Silencieux",
+			"ru": "Скрытый запуск",
+			"pl": "Ciche uruchomienie",
+			"cs": "Tichý start"
+		},
+		"Search visible blueprints (by Type, Name, Grade or Engineer) - split your terms with a space for multi-criteria search": {
+			"es": null,
+			"pt": "Procure diagramas disponíveis (por Tipo, Nome, Grau ou Engenheiro) - separe os termos com um espaço para pesquisa multi-critério",
+			"de": "Suche nach verfügbaren Bauplänen (Begriffe durch 'Leerzeichen' trennen)",
+			"fr": "Rechercher les plans de fabrications visible (par Type, Nom, Grade ou Ingénieur) - séparez vos termes avec un espace pour une recharche multi-critères",
+			"ru": "Поиск видимых чертежей (по Типу, Названию, Уровню или Инженеру) - введите условия через пробел для использования нескольких критериев сортировки",
+			"pl": "Przeszukaj widoczne schematy (po Typie, Nazwie, Poziomie lub nazwie Inżyniera) - oddziel terminy przy użyciu spacji by wyszukiwać za pomocą wielokrotnych kryterii",
+			"cs": "Hledat vyditelné plánky (podle typu, jména, grade nebo inženýra) - odděl hledané výrazy mezerou pro vyhledání všech výrazů najednou"
+		},
+		"Configure Notifications": {
+			"es": "Configurar Notificaciones",
+			"pt": "Configurar notificações",
+			"de": "Benachrichtigung Konfigurieren",
+			"fr": "Configurer les Notifications",
+			"ru": "Настройка оповещений",
+			"pl": "Skonfiguruj powiadomienia",
+			"cs": "Konfiguruj upozornění"
+		},
+		"Notifications": {
+			"es": "Notificaciones",
+			"pt": "Notificações",
+			"de": "Benachrichtigung",
+			"fr": "Notifications",
+			"ru": "Оповещения",
+			"pl": "Powiadomienia",
+			"cs": "Upozornění"
+		},
+		"Test Notification": {
+			"es": "Notificación de Prueba",
+			"pt": "Notificação de teste",
+			"de": "Test-Benachrichtigung",
+			"fr": "Tester la Notification",
+			"ru": "Проверка оповещения",
+			"pl": "Próbne powiadomienie",
+			"cs": "Testovat upozornění"
+		},
+		"Toast": {
+			"es": null,
+			"pt": "Notificação",
+			"de": "Toast",
+			"fr": "Notification",
+			"ru": "Toast",
+			"pl": "Pop-up",
+			"cs": "Pop-up"
+		},
+		"Voice": {
+			"es": "Voz",
+			"pt": "Voz",
+			"de": "Stimme",
+			"fr": "Voix",
+			"ru": "Голос",
+			"pl": "Głos",
+			"cs": "Hlas"
+		},
+		"Long Range Scanner": {
+			"es": "Escáner de Largo Alcance",
+			"pt": "Scanner de longo alcance",
+			"de": "Langstrecken-Scanner",
+			"fr": "Scanner Longue Portée",
+			"ru": "Сканер увеличенной дальности",
+			"pl": "Long Range Scanner",
+			"cs": "Long Range Scanner"
+		},
+		"Wide Angle Scanner": {
+			"es": null,
+			"pt": "Scanner de ângulo amplo",
+			"de": "Weitwinkel-Scanner",
+			"fr": "Scanner à Angle Large",
+			"ru": "Широкоугольный сканер",
+			"pl": "Wide Angle Scanner",
+			"cs": "Wide Angle Scanner"
+		},
+		"Light Weight Scanner": {
+			"es": null,
+			"pt": "Scanner leve",
+			"de": "Leichter Scanner",
+			"fr": "Scanner Léger",
+			"ru": "Облегченный сканер",
+			"pl": "Light Weight Scanner",
+			"cs": "Light Weight Scanner"
+		},
+		"Fast Scanner": {
+			"es": "Escáner Rápido",
+			"pt": "Scanner rápido",
+			"de": "Schneller Scanner",
+			"fr": "Scanner Rapide",
+			"ru": "Быстрый сканер",
+			"pl": "Fast Scanner",
+			"cs": "Fast Scanner"
+		},
+		"Unlock": {
+			"es": "Desbloquear",
+			"pt": "Desbloquear",
+			"de": "Freischalten",
+			"fr": "Déverrouiller",
+			"ru": "Расшифровка",
+			"pl": "Odblokowanie",
+			"cs": "Odemknutí"
+		},
+		"Available Voices:": {
+			"es": "Voces Disponibles",
+			"pt": "Vozes disponiveis",
+			"de": "verfügbare Stimmen",
+			"fr": "Voix Disponibles",
+			"ru": "Доступные голоса:",
+			"pl": "Dostępne głosy:",
+			"cs": "Dostupné hlasy:"
+		},
+		"filtered entries - click this to clear": {
+			"es": "entradas filtradas - haz clic aquí para limpiar",
+			"pt": "Entradas filtradas - Clique nela para limpar",
+			"de": "Gefilterte Einträge - Klick HIER um zu Löschen",
+			"fr": "entrées filtrées - cliquez ici pour nettoyer",
+			"ru": "отфильтрованные записи - нажмите для очистки",
+			"pl": null,
+			"cs": "Filtrované záznamy - klikni pro vyčistění"
+		},
+		"Thargoid Material Composition Data": {
+			"es": "Datos de Composición de Material Thargoide",
+			"pt": "Dados de composição de material Thargoid",
+			"de": "unbekannte Materialzusammensetzung",
+			"fr": "Donnée de Composition de Matérel Thargoid",
+			"ru": "Данные о составе таргоидских материалов",
+			"pl": null,
+			"cs": "Thargoid Material Composition Data"
+		},
+		"Thargoid Residue Data": {
+			"es": "Datos de Residuo Thargoide",
+			"pt": "Dados de resíduo Thargoid",
+			"de": "unbekannte Rückstandsdatenanalyse",
+			"fr": "Résidus de Données Thargoid",
+			"ru": "Данные об осадке таргоидского происхождения",
+			"pl": null,
+			"cs": "Thargoid Residue Data"
+		},
+		"Thargoid Structural Data": {
+			"es": "Datos Estructurales Thargoide",
+			"pt": "Dados de Estrutura Thargoid",
+			"de": "unbekannte Strukturdaten",
+			"fr": "Données Structurelles Thargoid",
+			"ru": "Данные о структуре таргоидского объекта",
+			"pl": null,
+			"cs": "Thargoid Structural Data"
+		},
+		"Thargoid Carapace": {
+			"es": "Caparazón Thargoide",
+			"pt": "Carapaça Thargoid",
+			"de": "unbekannte Panzerung",
+			"fr": "Carapace Thargoid",
+			"ru": "Таргоидский панцирь",
+			"pl": null,
+			"cs": "Thargoid Carapace"
+		},
+		"Thargoid Energy Cell": {
+			"es": "Célula de Energía Thargoide",
+			"pt": "Célula de Energia Thargoid",
+			"de": "unbekannte Energiezelle",
+			"fr": "Cellule d'Énergie Thargoid",
+			"ru": "Таргоидская энергоячейка",
+			"pl": null,
+			"cs": "Thargoid Energy Cell"
+		},
+		"Thargoid Organic Circuitry": {
+			"es": "Circuitería Orgánica Thargoide",
+			"pt": "Circuito Orgânico Thargoid",
+			"de": "unbekannte organische Struktur",
+			"fr": "Circuit Organique Thargoid",
+			"ru": "Таргоидская органическая схема",
+			"pl": null,
+			"cs": "Thargoid Organic Circuitry"
+		},
+		"Thargoid Technological Components": {
+			"es": "Componentes Tecnológicos Thargoide",
+			"pt": "Componente Tecnológico Thargoid",
+			"de": "unbekannte Technologie-Komponente",
+			"fr": "Composants Technologique Thargoid",
+			"ru": "Компоненты таргоидской техники",
+			"pl": null,
+			"cs": "Thargoid Technological Components"
+		},
+		"Ship Flight Data": {
+			"es": "Datos de Vuelos de Nave",
+			"pt": "Dados de voo da nave",
+			"de": "Schiff-Flug-Daten",
+			"fr": "Donnée de Vol",
+			"ru": "Полетные данные корабля",
+			"pl": null,
+			"cs": "Ship Flight Data"
+		},
+		"Ship System Data": {
+			"es": "Datos de Sistemas de Nave",
+			"pt": "Dados do sistema da nave",
+			"de": "Schiff-System-Daten",
+			"fr": "Données de Système de Navigation",
+			"ru": "Данные бортовых систем корабля",
+			"pl": null,
+			"cs": "Ship System Data"
+		},
+		"Wreckage Components": {
+			"es": "Restos de Accidentes",
+			"pt": "Destroços de componentes",
+			"de": "Wrackteile",
+			"fr": "Composants d'Épave",
+			"ru": "Обломки кораблекрушений",
+			"pl": null,
+			"cs": "Wreckage Components"
+		},
+		"Weapon Parts": {
+			"es": "Piezas de Armamento",
+			"pt": "Partes de armas",
+			"de": "Waffenteile",
+			"fr": "Éléments d'Arme",
+			"ru": "Детали вооружения",
+			"pl": null,
+			"cs": "Weapon Parts"
+		},
+		"Bio-Mechanical Conduits": {
+			"es": "Conductos Bio-Mecánicos",
+			"pt": "Condutores Bio-mecânicos",
+			"de": "Bio-mechanische Leitungen",
+			"fr": "Conducteurs Bio-Mécanique",
+			"ru": "Биомеханические энергопроводники",
+			"pl": null,
+			"cs": "Bio-Mechanical Conduits"
+		},
+		"Propulsion Elements": {
+			"es": "Elementos de Propulsión",
+			"pt": "Elementos de Propulsão",
+			"de": "Antriebselemente",
+			"fr": "Elements de Propulsion",
+			"ru": "Реактивные элементы",
+			"pl": null,
+			"cs": "Propulsion Elements"
+		},
+		"Settings": {
+			"es": "Ajustes",
+			"pt": "Configurações",
+			"de": "Einstellungen",
+			"fr": "Paramètres",
+			"ru": "Настройки",
+			"pl": null,
+			"cs": "Nastavení"
+		},
+		"Configure Graphics": {
+			"es": "Ajustes Gráficos",
+			"pt": "Configurar gráficos",
+			"de": "Grafik einstellen",
+			"fr": "Configuration Graphique",
+			"ru": "Настройки графики",
+			"pl": null,
+			"cs": "Nastav grafiku"
+		},
+		"100% Refill": {
+			"es": "100% de Recarga",
+			"pt": "100% de Recarga",
+			"de": "100% Nachfüllung",
+			"fr": "100% de Recharge",
+			"ru": "100% заправка",
+			"pl": null,
+			"cs": "100% doplnění"
+		},
+		"100% Refill, +15% Heat Dissipation": {
+			"es": "100% de Recarga, +15% de Disipación de Calor",
+			"pt": "100% de Recarga, +15% de Dissipação de Calor",
+			"de": "100% Nachfüllung, +15% Wärmeableitung",
+			"fr": "100% de Recharge, +15% de Dissipation de Chaleur",
+			"ru": "100% заправка, +15% рассеивание тепла",
+			"pl": null,
+			"cs": "100% doplnění, +15% odvod tepla"
+		},
+		"100% Refill, +2 Seconds Duration": {
+			"es": "100% de Recarga, +2 Segundos de Duración",
+			"pt": "100% de Recarga, +2 Segundos de Duração",
+			"de": "100% Nachfüllung, +2 Sekunden Dauer",
+			"fr": "100% de Recharge, +2 Secondes de Durée",
+			"ru": "100% заправка, +2 секунды действия",
+			"pl": null,
+			"cs": "100% doplnění, +2 sekundy k trvání"
+		},
+		"100% Refill, +30% Heat Dissipation": {
+			"es": "100% de Recarga, +30% de Disipación de Calor",
+			"pt": "100% de Recarga, +30% de Dissipação de Calor",
+			"de": "100% Nachfüllung, +30% Wärmeableitung",
+			"fr": "100% de Recharge, +30% de Dissipation de Chaleur",
+			"ru": "100% заправка, +30% рассеивание тепла",
+			"pl": null,
+			"cs": "100% doplnění, +30% odvod tepla"
+		},
+		"4 Limpets, Cargo Hold Required": {
+			"es": "4 Drones, Espacio de Carga Necesario",
+			"pt": "4 Drones, Porão de Carga Necessário ",
+			"de": "für Drohnen, Laderaum erforderlich",
+			"fr": "4 Drones, Soute Requise",
+			"ru": "4 беспилотника, необходим грузовой отсек",
+			"pl": null,
+			"cs": "4 Limpety, Vyžadován nákladový prostor (cargo)"
+		},
+		"50% Refill": {
+			"es": "50% de Recarga",
+			"pt": "50% de Recarga",
+			"de": "50% Nachfüllung",
+			"fr": "50% de Recharge",
+			"ru": "50% заправка",
+			"pl": null,
+			"cs": "50% doplnění"
+		},
+		"Fujin Tea": {
+			"es": "Té de Fujin",
+			"pt": "Chá de Fujin",
+			"de": "Fujin-Tee",
+			"fr": "Thé Fujin",
+			"ru": "Чай Fujin",
+			"pl": null,
+			"cs": "Fujin Tea"
+		},
+		"Gold": {
+			"es": "Oro",
+			"pt": "Ouro",
+			"de": "Gold",
+			"fr": "Or",
+			"ru": "Золото",
+			"pl": null,
+			"cs": "Gold"
+		},
+		"Kamitra Cigars": {
+			"es": null,
+			"pt": "Charutos de Kamitra",
+			"de": "Kamitra-Zigarren",
+			"fr": "Cigares de Kamitra",
+			"ru": "Сигары Kamitra",
+			"pl": null,
+			"cs": "Kamitra Cigars"
+		},
+		"Kongga Ale": {
+			"es": "Cerveza de Kongga",
+			"pt": "Cerveja de Kongga",
+			"de": "Kongga-Bier",
+			"fr": "Bière de Kongga",
+			"ru": "Эль Конгга",
+			"pl": null,
+			"cs": "Kongga Ale"
+		},
+		"Landmines": {
+			"es": "Minas Terrestres",
+			"pt": "Minas Terrestres",
+			"de": "Landminen",
+			"fr": "Mines Terrestres",
+			"ru": "Мины",
+			"pl": null,
+			"cs": "Landmines"
+		},
+		"Lavian Brandy": {
+			"es": "Brandy Laviano",
+			"pt": "Brandy Laviano",
+			"de": "Lave-Brandy",
+			"fr": "Cognac Lavien",
+			"ru": "Лавианский бренди",
+			"pl": null,
+			"cs": "Lavian Brandy"
+		},
+		"Limpets": {
+			"es": "Drones",
+			"pt": "Drones",
+			"de": "Drohnen",
+			"fr": "Drones",
+			"ru": "Беспилотники",
+			"pl": null,
+			"cs": "Limpety"
+		},
+		"Meta-alloys": {
+			"es": "Meta-aleaciones",
+			"pt": "Meta-Ligas",
+			"de": "Meta-Legierungen",
+			"fr": "Meta-Alliages",
+			"ru": "Метасплавы",
+			"pl": null,
+			"cs": "Meta-alloys"
+		},
+		"Painite": {
+			"es": null,
+			"pt": "Painita",
+			"de": "Painit",
+			"fr": "Painite",
+			"ru": "Пейнит",
+			"pl": null,
+			"cs": "Painite"
+		},
+		"Soontill Relics": {
+			"es": "Reliquias de Soontill",
+			"pt": "Relíquias de Soontill",
+			"de": "Soontil Relikte",
+			"fr": "Relique de Soontill",
+			"ru": "Реликты Сунтилла",
+			"pl": null,
+			"cs": "Soontill Relics"
+		},
+		"Xihe Companions": {
+			"es": null,
+			"pt": "Companheiros Xihe",
+			"de": "Haustiere von Xihe",
+			"fr": "Compagnions Xihe",
+			"ru": "Спутники Xihe",
+			"pl": null,
+			"cs": "Xihe Companions"
+		},
+		"Raw": {
+			"es": null,
+			"pt": "Bruto",
+			"de": "roh",
+			"fr": "À l'état brut",
+			"ru": "Неочищенные минералы",
+			"pl": null,
+			"cs": "Surové (Raw)"
+		},
+		"Raw Only": {
+			"es": null,
+			"pt": "Apenas Bruto",
+			"de": "nur roh",
+			"fr": "Uniquement à l'état brut",
+			"ru": "Только неочищенные минералы",
+			"pl": null,
+			"cs": "Pouze surové(Raw only)"
+		},
+		"Manufactured": {
+			"es": "Manufacturado(s)",
+			"pt": "Fabricado",
+			"de": "hergestellt",
+			"fr": "Manufacturé(s)",
+			"ru": "Компоненты",
+			"pl": null,
+			"cs": "Vyrobené(Manufactured)"
+		},
+		"Manufactured Only": {
+			"es": "Solo manufacturado(s)",
+			"pt": "Apenas Fabricado",
+			"de": "nur hergestellt",
+			"fr": "Uniquement manufacturé(s)",
+			"ru": "Только компоненты",
+			"pl": null,
+			"cs": "Pouze vyrobené(Manufact.only)"
+		},
+		"Unrecognized Ingredient (showing name as it appears in the logs). Please open a GitHub issue to let the author know what is the real name of this!": {
+			"es": "Ingrediente no reconocido (mostrando el nombre como aparece en los logs). Por favor abra un asunto en GitHub para notificar al autor cuál es el nombre real the este ingrediente!",
+			"pt": "Ingrediente não reconhecido (mostrando o nome como aparece nos registros). Abra um problema do GitHub para que o autor saiba qual é o nome verdadeiro disso!",
+			"de": "Unbekannter Bestandteil (zeigt den Namen, wie er in den Protokollen erscheint). Bitte öffnen Sie ein GitHub-Issue, um den Autor wissen zu lassen, wie dieser wirklich heißt!",
+			"fr": null,
+			"ru": "Нераспознанный ингредиент (отображается название из логов). Пожалуйста, создайте issue на GitHub, чтобы оповестить разработчика о фактическом названии!",
+			"pl": null,
+			"cs": "Nerozpoznaná ingredience (Zobrazené jméno je tak, jak se vyskytuje v logu). Prosím otevřete požadavek na GitHubu a dejte vědět autorovi správný název ingredience!"
+		},
+		"Group ingredients?": {
+			"es": "Grupo de ingredientes?",
+			"pt": null,
+			"de": "Gruppenzutaten?",
+			"fr": "Groupe d'ingrédients ?",
+			"ru": "Группировать ингредиенты?",
+			"pl": null,
+			"cs": "Seskupovat ingredience?"
+		},
+		"Unknown": {
+			"es": "Desconocido",
+			"pt": "Desconhecido",
+			"de": "Unbekannt",
+			"fr": "Inconnu",
+			"ru": "Неизвестные",
+			"pl": null,
+			"cs": "Neznámé"
+		},
+		"Carrying ": {
+			"es": "Transportando",
+			"pt": null,
+			"de": "Trasportieren ",
+			"fr": "Capacité",
+			"ru": "В наличии ",
+			"pl": null,
+			"cs": "Vlastněno "
+		},
+		"Emission Data": {
+			"es": "Datos de emisión",
+			"pt": null,
+			"de": "Emissionsdaten",
+			"fr": "Données d'émission",
+			"ru": "Данные об излучениях",
+			"pl": null,
+			"cs": "Emission Data"
+		},
+		"Wake Scans": {
+			"es": "Escaneos de estela",
+			"pt": null,
+			"de": "Sogwolken Scans",
+			"fr": "Données de sillages",
+			"ru": "Сканирования следа FSD",
+			"pl": null,
+			"cs": "Wake Scans"
+		},
+		"Shield Data": {
+			"es": "Datos de escudo",
+			"pt": null,
+			"de": "Schilddaten",
+			"fr": "Données de bouclier",
+			"ru": "Данные о щитах",
+			"pl": null,
+			"cs": "Shield Data"
+		},
+		"Encryption Files": {
+			"es": "Archivos de encriptación",
+			"pt": null,
+			"de": "Verschlüsselungsdaten",
+			"fr": "Fichiers cryptés",
+			"ru": "Файлы шифрования",
+			"pl": null,
+			"cs": "Encryption Files"
+		},
+		"Data Archives": {
+			"es": "Archivos de datos",
+			"pt": null,
+			"de": "Datenarchive",
+			"fr": "Archives de données",
+			"ru": "Архивы данных",
+			"pl": null,
+			"cs": "Data Archives"
+		},
+		"Encoded Firmware": {
+			"es": null,
+			"pt": null,
+			"de": "Codierte Firmware",
+			"fr": "Micrologiciels encodés",
+			"ru": "Закодированные микропрограммы",
+			"pl": null,
+			"cs": "Encoded Firmware"
+		},
+		"Category 1": {
+			"es": "Categoría 1",
+			"pt": "Categoria 1",
+			"de": "Kategorie 1",
+			"fr": "Matériaux bruts - Catégorie 1",
+			"ru": "Категория 1",
+			"pl": null,
+			"cs": "Kategorie 1"
+		},
+		"Category 2": {
+			"es": "Categoría 2",
+			"pt": "Categoria 2",
+			"de": "Kategorie 2",
+			"fr": "Matériaux bruts - Catégorie 2",
+			"ru": "Категория 2",
+			"pl": null,
+			"cs": "Kategorie 2"
+		},
+		"Category 3": {
+			"es": "Categoría 3",
+			"pt": "Categoria 3",
+			"de": "Kategorie 3",
+			"fr": "Matériaux bruts - Catégorie 3",
+			"ru": "Категория 3",
+			"pl": null,
+			"cs": "Kategorie 3"
+		},
+		"Category 4": {
+			"es": "Categoría 4",
+			"pt": "Categoria 4",
+			"de": "Kategorie 4",
+			"fr": "Matériaux bruts - Catégorie 4",
+			"ru": "Категория 4",
+			"pl": null,
+			"cs": "Kategorie 4"
+		},
+		"Category 5": {
+			"es": "Categoría 5",
+			"pt": "Categoria 5",
+			"de": "Kategorie 5",
+			"fr": "Matériaux bruts - Catégorie 5",
+			"ru": "Категория 5",
+			"pl": null,
+			"cs": "Kategorie 5"
+		},
+		"Category 6": {
+			"es": "Categoría 6",
+			"pt": "Categoria 6",
+			"de": "Kategorie 6",
+			"fr": "Matériaux bruts - Catégorie 6",
+			"ru": "Категория 6",
+			"pl": null,
+			"cs": "Kategorie 6"
+		},
+		"Category 7": {
+			"es": "Categoría 7",
+			"pt": "Categoria 7",
+			"de": "Kategorie 7",
+			"fr": "Matériaux bruts - Catégorie 7",
+			"ru": "Категория 7",
+			"pl": null,
+			"cs": "Kategorie 7"
+		},
+		"Chemical": {
+			"es": "Químico",
+			"pt": null,
+			"de": "Chemikalien",
+			"fr": "Produits chimiques",
+			"ru": "Химикаты",
+			"pl": null,
+			"cs": "Chemické (Chemical)"
+		},
+		"Thermic": {
+			"es": "Térmico",
+			"pt": "Térmico",
+			"de": "Thermisch",
+			"fr": "Thermiques",
+			"ru": "Термические сплавы",
+			"pl": null,
+			"cs": "Termické (Thermic)"
+		},
+		"Heat": {
+			"es": "Calor",
+			"pt": null,
+			"de": "Hitze",
+			"fr": "Chaleur",
+			"ru": "Теплообмен",
+			"pl": null,
+			"cs": "Tepelné (Heat)"
+		},
+		"Conductive": {
+			"es": "Conductivo",
+			"pt": null,
+			"de": "Leiter",
+			"fr": "Conducteurs",
+			"ru": "Проводники",
+			"pl": null,
+			"cs": "Konduktivní (Conductive)"
+		},
+		"Capacitors": {
+			"es": "Condensadores",
+			"pt": null,
+			"de": "Kondensatoren",
+			"fr": "Condensateurs",
+			"ru": "Конденсаторы",
+			"pl": null,
+			"cs": "Kondenzátory (Capacitors)"
+		},
+		"Shielding": {
+			"es": "Protección",
+			"pt": null,
+			"de": "Abschirmung",
+			"fr": "Protection",
+			"ru": "Защита",
+			"pl": null,
+			"cs": "Stínění (Shielding)"
+		},
+		"Composite": {
+			"es": "Compuesto",
+			"pt": null,
+			"de": "Komposite",
+			"fr": "Composites",
+			"ru": "Композиты",
+			"pl": null,
+			"cs": "Kompozity (Composite)"
+		},
+		"Crystals": {
+			"es": "Cristales",
+			"pt": null,
+			"de": "Kristalle",
+			"fr": "Cristaux",
+			"ru": "Кристаллы",
+			"pl": null,
+			"cs": "Krystaly (Crystals)"
+		},
+		"Alloys": {
+			"es": "Aleaciones",
+			"pt": "Ligas",
+			"de": "Legierungen",
+			"fr": "Alliages",
+			"ru": "Сплавы",
+			"pl": null,
+			"cs": "Slitiny (Alloys)"
+		},
+		"Lead": {
+			"es": "Plomo",
+			"pt": "Chumbo",
+			"de": "Blei",
+			"fr": null,
+			"ru": "Свинец",
+			"pl": null,
+			"cs": "Lead"
+		},
+		"Boron": {
+			"es": "Boro",
+			"pt": "Boro",
+			"de": "Bor",
+			"fr": null,
+			"ru": "Бор",
+			"pl": null,
+			"cs": "Boron"
+		},
+		"Guardian Weapon Blueprint Segment": {
+			"es": "Fragmento de Plano de Armamento de Guardián",
+			"pt": "Segmento de Diagrama de Arma Guardian",
+			"de": "Guardian-Waffenbauplansegment",
+			"fr": null,
+			"ru": "Фрагмент чертежа оружия стражей",
+			"pl": null,
+			"cs": "Guardian Weapon Blueprint Segment"
+		},
+		"Guardian Power Cell": {
+			"es": "Célula de Energía de Guardián",
+			"pt": "Bateria Guardian",
+			"de": "Guardian-Energiezelle",
+			"fr": null,
+			"ru": "Энергоячейка стражей",
+			"pl": null,
+			"cs": "Guardian Power Cell"
+		},
+		"Guardian Technology Component": {
+			"es": "Componente Tecnológico de Guardián",
+			"pt": "Componente de Tecnologia Guardian",
+			"de": "Guardian-Technologiekomponente",
+			"fr": null,
+			"ru": "Компоненты технологий стражей",
+			"pl": null,
+			"cs": "Guardian Technology Component"
+		},
+		"Guardian Power Conduit": {
+			"es": "Conducto de Energía Guardián",
+			"pt": "Condutores de Potência Guardian",
+			"de": "Guardian-Energieleiter",
+			"fr": null,
+			"ru": "Энергопроводники стражей",
+			"pl": null,
+			"cs": "Guardian Power Conduit"
+		},
+		"Guardian Sentinel Weapon Parts": {
+			"es": "Piezas de Armamento de Centinela Guardián",
+			"pt": "Peças de Armas Sentinela Guardian",
+			"de": "Guardian-Wache-Waffenteile",
+			"fr": null,
+			"ru": "Детали вооружения стража Sentinel",
+			"pl": null,
+			"cs": "Guardian Sentinel Weapon Parts"
+		},
+		"Guardian Module Blueprint Segment": {
+			"es": "Fragmento de Plano de Módulo de Guardián",
+			"pt": "Segmento de Diagrama de Módulo Guardian",
+			"de": "Guardian-Modulbauplansegment",
+			"fr": null,
+			"ru": "Фрагмент чертежа модуля стражей",
+			"pl": null,
+			"cs": "Guardian Module Blueprint Segment"
+		},
+		"Guardian Sentinel Wreckage Components": {
+			"es": "Restos de accidentes de Guardián",
+			"pt": "Componentes de Destroços Sentinela Guardian",
+			"de": "Guardian-Wache Trümmerteile",
+			"fr": null,
+			"ru": "Обломки кораблекрушений стража Sentinel",
+			"pl": null,
+			"cs": "Guardian Sentinel Wreckage Components"
+		},
+		"Guardian Vessel Blueprint Segment": {
+			"es": "Fragmento de Plano de Nave de Guardián",
+			"pt": null,
+			"de": "Guardian-Schiffsbauplansegment",
+			"fr": null,
+			"ru": "Фрагмент чертежа судна стражей",
+			"pl": null,
+			"cs": "Guardian Vessel Blueprint Segment"
+		},
+		"Human": {
+			"es": "Humano",
+			"pt": "Humano",
+			"de": "Menschlich",
+			"fr": null,
+			"ru": "Технологии людей",
+			"pl": null,
+			"cs": "Lidské"
+		},
+		"Corrosion Resistant Cargo Rack (2D and 4D)": {
+			"es": "Bodega de carga resistente a corrosión (2D y 4D)",
+			"pt": "Estante de Carga Anti-Corrosiva (2D e 4D)",
+			"de": "Korrosionsresistentes Frachtegtell (2D and 4D)",
+			"fr": null,
+			"ru": "Коррозийно-устойчивый грузовой стеллаж (2D и 4D)",
+			"pl": null,
+			"cs": "Corrosion Resistant Cargo Rack (2D and 4D)"
+		},
+		"Enzyme Missile Rack": {
+			"es": null,
+			"pt": "Estante de Mísseis Enzimáticos",
+			"de": "Enzym Raketenrampe",
+			"fr": null,
+			"ru": "Блок энзимных ракет",
+			"pl": null,
+			"cs": "Enzyme Missile Rack"
+		},
+		"Guardian": {
+			"es": "Guardián",
+			"pt": "Guardian",
+			"de": "Guardian",
+			"fr": null,
+			"ru": "Технологии стражей",
+			"pl": null,
+			"cs": "Guardiánské"
+		},
+		"Guardian Ruins": {
+			"es": "Ruinas Guardianes",
+			"pt": null,
+			"de": null,
+			"fr": null,
+			"ru": null,
+			"pl": null,
+			"cs": null
+		},
+		"Guardian Ruins (Active)": {
+			"es": "Ruinas Guardianes (Activas)",
+			"pt": null,
+			"de": null,
+			"fr": null,
+			"ru": null,
+			"pl": null,
+			"cs": null
+		},
+		"Guardian Gauss Cannon (Fixed)": {
+			"es": "Cañón Gauss Guardián (Fijo)",
+			"pt": "Canhão Gauss Guardian (Fixa)",
+			"de": "Guardian-Gausskannone (Fest)",
+			"fr": "Canon de gauss - Guardians (Fixe)",
+			"ru": "Пушка Гаусса стражей (фиксированное)",
+			"pl": null,
+			"cs": "Guardian Gauss Cannon (Fixed)"
+		},
+		"Guardian Plasma Charger (Fixed)": {
+			"es": "Cargador de Plasma Guardián (Fijo)",
+			"pt": "Carregador de Plasma Guardian (Fixa)",
+			"de": "Guardian-Plasmalader (Fest)",
+			"fr": "Chargeur à plasma - Guardians (Fixe)",
+			"ru": "Плазменная пушка стражей (фиксированное)",
+			"pl": null,
+			"cs": "Guardian Plasma Charger (Fixed)"
+		},
+		"Guardian Plasma Charger (Turreted)": {
+			"es": "Cargador de Plasma Guardián (Torreta)",
+			"pt": "Carregador de Plasma Guardian (Torretada)",
+			"de": "Guardian-Plasmalader (Turm)",
+			"fr": "Chargeur à plasma - Guardians (Tourelle)",
+			"ru": "Плазменная пушка стражей (турель)",
+			"pl": null,
+			"cs": "Guardian Plasma Charger (Turreted)"
+		},
+		"Guardian Hybrid Power Plant": {
+			"es": "Núcleo de energía Guardián",
+			"pt": "Gerador de Energia Guardian",
+			"de": "Guardian-Kraftwerk",
+			"fr": "Générateur - Guardians",
+			"ru": "Силовая установка стражей",
+			"pl": null,
+			"cs": "Guardian Hybrid Power Plant"
+		},
+		"Meta Alloy Hull Reinforcement": {
+			"es": null,
+			"pt": null,
+			"de": "Meta-Legierung-Hüllenverstärkung",
+			"fr": null,
+			"ru": "Метасплавное усиление корпуса",
+			"pl": null,
+			"cs": "Meta Alloy Hull Reinforcement"
+		},
+		"Remote Release Flechette Launcher (Fixed)": {
+			"es": null,
+			"pt": "Lançador de dardos de Liberação Remota (Fixa)",
+			"de": "ferngesteuerter Flechettenwerfer (Fest)",
+			"fr": null,
+			"ru": "Зенитная установка с дистанционным подрывом (фиксированное)",
+			"pl": null,
+			"cs": "Remote Release Flechette Launcher (Fixed)"
+		},
+		"Remote Release Flechette Launcher (Turreted)": {
+			"es": null,
+			"pt": "Lançador de dardos de Liberação Remota (Torretada)",
+			"de": "ferngesteuerter Flechettenwerfer (Turm)",
+			"fr": null,
+			"ru": "Зенитная установка с дистанционным подрывом (турель)",
+			"pl": null,
+			"cs": "Remote Release Flechette Launcher (Turreted)"
+		},
+		"Shock Cannon (Fixed)": {
+			"es": "Cañon de choque (Fijo)",
+			"pt": "Canhão Elétrico (Fixa)",
+			"de": "Schock Kanone (Fest)",
+			"fr": null,
+			"ru": "Шоковое орудие (фиксированное)",
+			"pl": null,
+			"cs": "Shock Cannon (Fixed)"
+		},
+		"Shock Cannon (Gimballed)": {
+			"es": "Cañon de choque (Guiado)",
+			"pt": "Canhão Elétrico (Guiada)",
+			"de": "Schock Kanone (Kardanisch)",
+			"fr": null,
+			"ru": "Шоковое орудие (на карданной подвеске)",
+			"pl": null,
+			"cs": "Shock Cannon (Gimballed)"
+		},
+		"Shock Cannon (Turreted)": {
+			"es": "Cañon de choque (Torreta)",
+			"pt": "Canhão Elétrico (Torretada)",
+			"de": "Schock Kanone (Turm)",
+			"fr": null,
+			"ru": "Шоковое орудие (турель)",
+			"pl": null,
+			"cs": "Shock Cannon (Turreted)"
+		},
+		"Concordant Sequence": {
+			"es": "Secuencia Concordante",
+			"pt": null,
+			"de": "gleichsinnige Sequenz",
+			"fr": null,
+			"ru": "Последовательность координации",
+			"pl": null,
+			"cs": "Concordant Sequence"
+		},
+		"Regeneration Sequence": {
+			"es": "Secuencia de Regeneración",
+			"pt": null,
+			"de": "regenerierende Sequenz",
+			"fr": null,
+			"ru": "Последовательность восстановления",
+			"pl": null,
+			"cs": "Regeneration Sequence"
+		},
+		"Thermal Conduit": {
+			"es": "Conductor Térmico",
+			"pt": null,
+			"de": "Hitzerohr",
+			"fr": null,
+			"ru": "Проводник тепла",
+			"pl": null,
+			"cs": "Thermal Conduit"
+		},
+		"Thermal Shock": {
+			"es": "Choque Térmico",
+			"pt": null,
+			"de": "Thermischer Schock",
+			"fr": null,
+			"ru": "Тепловой удар",
+			"pl": null,
+			"cs": "Thermal Shock"
+		},
+		"Thermal Vent": {
+			"es": "Respiradero Térmico",
+			"pt": null,
+			"de": "Thermische Entlastung",
+			"fr": null,
+			"ru": "Теплоотдача",
+			"pl": null,
+			"cs": "Thermal Vent"
+		},
+		"Oversized": {
+			"es": "Sobredimensionado",
+			"pt": null,
+			"de": "Übergröße",
+			"fr": null,
+			"ru": "Сверхразмер",
+			"pl": null,
+			"cs": "Oversized"
+		},
+		"Stripped Down": {
+			"es": "Despojado",
+			"pt": null,
+			"de": "Reduktion",
+			"fr": null,
+			"ru": "Урезанный вариант",
+			"pl": null,
+			"cs": "Stripped Down"
+		},
+		"Double Braced": {
+			"es": null,
+			"pt": null,
+			"de": "Doppelt Versteift",
+			"fr": null,
+			"ru": "Двойная прочность",
+			"pl": null,
+			"cs": "Double Braced"
+		},
+		"Flow Control": {
+			"es": null,
+			"pt": null,
+			"de": "Flusssteuerung",
+			"fr": null,
+			"ru": "Контроль интенсивности",
+			"pl": null,
+			"cs": "Flow Control"
+		},
+		"Inertial Impact": {
+			"es": "Impacto Inercial",
+			"pt": null,
+			"de": "Trägheitseinfluss",
+			"fr": null,
+			"ru": "Инерционный удар",
+			"pl": null,
+			"cs": "Inertial Impact"
+		},
+		"Phasing Sequence": {
+			"es": null,
+			"pt": null,
+			"de": "Phasensequenz",
+			"fr": null,
+			"ru": "Последовательность фазирования",
+			"pl": null,
+			"cs": "Phasing Sequence"
+		},
+		"Scramble Spectrum": {
+			"es": null,
+			"pt": null,
+			"de": "Mischungsbandbreite",
+			"fr": null,
+			"ru": "Отключающая сетка",
+			"pl": null,
+			"cs": "Scramble Spectrum"
+		},
+		"Multi-Servos": {
+			"es": null,
+			"pt": null,
+			"de": "Multi-Servos",
+			"fr": null,
+			"ru": "Сервосистема",
+			"pl": null,
+			"cs": "Multi-Servos"
+		},
+		"Emissive Munitions": {
+			"es": null,
+			"pt": null,
+			"de": "Emissionsgranate",
+			"fr": null,
+			"ru": "Эмиссионные припасы",
+			"pl": null,
+			"cs": "Emissive Munitions"
+		},
+		"Auto Loader": {
+			"es": "Cargador automático",
+			"pt": null,
+			"de": "Auto-Laden",
+			"fr": null,
+			"ru": "Автоматическая система заряжания",
+			"pl": null,
+			"cs": "Auto Loader"
+		},
+		"Corrosive Shell": {
+			"es": null,
+			"pt": null,
+			"de": "Korrosionsgranate",
+			"fr": null,
+			"ru": "Разъедающие боеприпасы",
+			"pl": null,
+			"cs": "Corrosive Shell"
+		},
+		"Incendiary Rounds": {
+			"es": "Rondas Incendiarias",
+			"pt": null,
+			"de": "Hitzesalven",
+			"fr": null,
+			"ru": "Зажигательные припасы",
+			"pl": null,
+			"cs": "Incendiary Rounds"
+		},
+		"Smart Rounds": {
+			"es": "Rondas Inteligentes",
+			"pt": null,
+			"de": "Intelligente Munition",
+			"fr": null,
+			"ru": "Умные боеприпасы",
+			"pl": null,
+			"cs": "Smart Rounds"
+		},
+		"Dispersal Field": {
+			"es": "Campo de Dispersión",
+			"pt": null,
+			"de": "Streuungsfeld",
+			"fr": null,
+			"ru": "Рассеивающее поле",
+			"pl": null,
+			"cs": "Dispersal Field"
+		},
+		"Force Shell": {
+			"es": "Escudo de Fuerza",
+			"pt": null,
+			"de": "Impulsgranate",
+			"fr": null,
+			"ru": "Усиленные снаряды",
+			"pl": null,
+			"cs": "Force Shell"
+		},
+		"High Yield Shell": {
+			"es": null,
+			"pt": null,
+			"de": "Hocheffizienzgranate",
+			"fr": null,
+			"ru": "Снаряды большой мощности",
+			"pl": null,
+			"cs": "High Yield Shell"
+		},
+		"Thermal Cascade": {
+			"es": "Cascada Térmica",
+			"pt": null,
+			"de": "Thermalkaskade",
+			"fr": null,
+			"ru": "Термический залп",
+			"pl": null,
+			"cs": "Thermal Cascade"
+		},
+		"Dazzle Shell": {
+			"es": null,
+			"pt": null,
+			"de": "Blendgranate",
+			"fr": null,
+			"ru": "Ослепляющие снаряды",
+			"pl": null,
+			"cs": "Dazzle Shell"
+		},
+		"Drag Munition": {
+			"es": null,
+			"pt": null,
+			"de": "Ableitungsmunition",
+			"fr": null,
+			"ru": "Замедляющие боеприпасы",
+			"pl": null,
+			"cs": "Drag Munition"
+		},
+		"Screening Shell": {
+			"es": null,
+			"pt": null,
+			"de": "Sperrgranate",
+			"fr": null,
+			"ru": "Заслоняющие снаряды",
+			"pl": null,
+			"cs": "Screening Shell"
+		},
+		"Drag Munition (Seeker only)": {
+			"es": null,
+			"pt": null,
+			"de": "Ableitungsmunition (nur Suchraketen)",
+			"fr": null,
+			"ru": "Замедляющие боеприпасы (лоток с самонаведением)",
+			"pl": null,
+			"cs": "Drag Munition (Seeker only)"
+		},
+		"Overload Munitions": {
+			"es": null,
+			"pt": null,
+			"de": "Überladungsmunition",
+			"fr": null,
+			"ru": "Вызывающие перегрузку боеприпасы",
+			"pl": null,
+			"cs": "Overload Munitions"
+		},
+		"Penetrator Munitions (Dumbfire only)": {
+			"es": null,
+			"pt": null,
+			"de": "Penetrationsmunition",
+			"fr": null,
+			"ru": "Бронебойные боеголовки",
+			"pl": null,
+			"cs": "Penetrator Munitions (Dumbfire only)"
+		},
+		"FSD Interrupt (Dumbfire only)": {
+			"es": null,
+			"pt": null,
+			"de": "FSA-Unterbrechung (nur Dumbfire)",
+			"fr": null,
+			"ru": "Помеха для FSD",
+			"pl": null,
+			"cs": "FSD Interrupt (Dumbfire only)"
+		},
+		"Mass Lock Munition": {
+			"es": null,
+			"pt": null,
+			"de": "Massesperremunition",
+			"fr": null,
+			"ru": "Боеприпасы с гравитационным захватом",
+			"pl": null,
+			"cs": "Mass Lock Munition"
+		},
+		"Penetrator Payload": {
+			"es": null,
+			"pt": null,
+			"de": "Penetrationsmunition",
+			"fr": null,
+			"ru": "Бронебойные снаряды",
+			"pl": null,
+			"cs": "Penetrator Payload"
+		},
+		"Reverberating Cascade": {
+			"es": null,
+			"pt": null,
+			"de": "Rückstrahlkaskade",
+			"fr": null,
+			"ru": "Отраженный залп",
+			"pl": null,
+			"cs": "Reverberating Cascade"
+		},
+		"Ion Disruptor": {
+			"es": null,
+			"pt": null,
+			"de": "Ionen-Disruption",
+			"fr": null,
+			"ru": "Ионный дестабилизатор",
+			"pl": null,
+			"cs": "Ion Disruptor"
+		},
+		"Radiant Canister": {
+			"es": null,
+			"pt": null,
+			"de": "Strahlenbehältnis",
+			"fr": null,
+			"ru": "Светящаяся кассета",
+			"pl": null,
+			"cs": "Radiant Canister"
+		},
+		"Shift-Lock Canister": {
+			"es": null,
+			"pt": null,
+			"de": "Frameshift-Blocker",
+			"fr": null,
+			"ru": "Рамоблокирующая кассета",
+			"pl": null,
+			"cs": "Shift-Lock Canister"
+		},
+		"Target Lock Breaker": {
+			"es": null,
+			"pt": null,
+			"de": null,
+			"fr": null,
+			"ru": "Генератор помех для системы захвата цели",
+			"pl": null,
+			"cs": "Target Lock Breaker"
+		},
+		"Plasma Slug": {
+			"es": null,
+			"pt": null,
+			"de": "Plasmaprojektil",
+			"fr": null,
+			"ru": "Плазменный рельсовый заряд",
+			"pl": null,
+			"cs": "Plasma Slug"
+		},
+		"Feedback Cascade": {
+			"es": null,
+			"pt": null,
+			"de": "Rückkopplungskaskade",
+			"fr": null,
+			"ru": "Ответный залп",
+			"pl": null,
+			"cs": "Feedback Cascade"
+		},
+		"Super Penetrator": {
+			"es": null,
+			"pt": null,
+			"de": "Super-Durchdringer",
+			"fr": null,
+			"ru": "Модуль сверхпробития",
+			"pl": null,
+			"cs": "Super Penetrator"
+		},
+		"@Technology": {
+			"es": "@Tecnología",
+			"pt": null,
+			"de": "@Technologie",
+			"fr": null,
+			"ru": "@Технология",
+			"pl": null,
+			"cs": "@Technologie"
+		},
+		"Module": {
+			"es": "Módulo",
+			"pt": "Módulo",
+			"de": "Module",
+			"fr": null,
+			"ru": "Модули",
+			"pl": null,
+			"cs": "Moduly"
+		},
+		"Synthesis": {
+			"es": "Síntesis",
+			"pt": null,
+			"de": "Synthese",
+			"fr": null,
+			"ru": "Синтез",
+			"pl": null,
+			"cs": "Syntéza"
+		},
+		"Experimental": {
+			"es": "Experimental",
+			"pt": "Experimental",
+			"de": "Experimentell",
+			"fr": null,
+			"ru": "Экспериментальные",
+			"pl": null,
+			"cs": "Experimentální"
+		},
+		"Technology": {
+			"es": "Tecnología",
+			"pt": null,
+			"de": "Technologie",
+			"fr": null,
+			"ru": "Технологии",
+			"pl": null,
+			"cs": "Technologie"
+		},
+		"Ancient/Guardian ruins": {
+			"es": "Ruinas Antíguas/Guardianes",
+			"pt": null,
+			"de": "Uralte/Guardian Ruinen",
+			"fr": null,
+			"ru": "Руины стражей",
+			"pl": null,
+			"cs": "Starobylé/Guardiánské ruiny"
+		},
+		"EDEngineer will try to remove blueprints from your shopping list if you craft them in game": {
+			"es": "EDEngineer intentará eliminar planos de tu lista si los creas en el juego",
+			"pt": null,
+			"de": "EDEngineer wird versuchen, Blaupausen von Ihrer Einkaufsliste zu entfernen, wenn Sie sie im Spiel erstellen.",
+			"fr": null,
+			"ru": "EDEngineer попытается удалять чертежи из списка покупок при создании их в игре",
+			"pl": null,
+			"cs": "EDEngineer se pokusí odebrat plánky z vašeho nákupního seznamu, když je aplikujete ve hře"
+		},
+		"Thermal Spread": {
+			"es": null,
+			"pt": null,
+			"de": "Wärmeverteilung",
+			"fr": null,
+			"ru": "Рассеивание тепла",
+			"pl": null,
+			"cs": "Thermal Spread"
+		},
+		"Monstered": {
+			"es": null,
+			"pt": null,
+			"de": "monströs",
+			"fr": null,
+			"ru": "Монстрация",
+			"pl": null,
+			"cs": "Monstered"
+		},
+		"Angled Plating": {
+			"es": "Blindaje Angulado",
+			"pt": null,
+			"de": "Abgewinkelte Beschichtung",
+			"fr": null,
+			"ru": "Угловая броня",
+			"pl": null,
+			"cs": "Angled Plating"
+		},
+		"Layered Plating": {
+			"es": "Blindaje Compuesto",
+			"pt": null,
+			"de": "Mehrschichtige Beschichtung",
+			"fr": null,
+			"ru": "Многослойная броня",
+			"pl": null,
+			"cs": "Layered Plating"
+		},
+		"Reflective Plating": {
+			"es": "Blindaje Reflectante",
+			"pt": null,
+			"de": "Reflektierende Beschichtung",
+			"fr": null,
+			"ru": "Отражающая броня",
+			"pl": null,
+			"cs": "Reflective Plating"
+		},
+		"Deep Plating": {
+			"es": "Blindaje Profundo",
+			"pt": null,
+			"de": "Tiefenüberzug",
+			"fr": null,
+			"ru": "Утолщенная броня",
+			"pl": null,
+			"cs": "Deep Plating"
+		},
+		"Boss Cells": {
+			"es": null,
+			"pt": null,
+			"de": "Boss-Zellen",
+			"fr": null,
+			"ru": "Босс-ячейки",
+			"pl": null,
+			"cs": "Boss Cells"
+		},
+		"Recycling Cells": {
+			"es": "Celdas de Reciclaje",
+			"pt": null,
+			"de": "Recycling-Zellen",
+			"fr": null,
+			"ru": "Рециркуляционные ячейки",
+			"pl": null,
+			"cs": "Recycling Cells"
+		},
+		"Force Block": {
+			"es": null,
+			"pt": null,
+			"de": "Kraftsperre",
+			"fr": null,
+			"ru": "Усиленная блокировка",
+			"pl": null,
+			"cs": "Force Block"
+		},
+		"Thermo Block": {
+			"es": null,
+			"pt": null,
+			"de": "Wärmesperre",
+			"fr": null,
+			"ru": "Блокировка тепла",
+			"pl": null,
+			"cs": "Thermo Block"
+		},
+		"Blast Block": {
+			"es": null,
+			"pt": null,
+			"de": "Explosionssperre",
+			"fr": null,
+			"ru": "Блокировка взрыва",
+			"pl": null,
+			"cs": "Blast Block"
+		},
+		"Super Capacitor": {
+			"es": "Super Condensador",
+			"pt": null,
+			"de": "Superkondensatoren",
+			"fr": null,
+			"ru": "Суперконденсатор",
+			"pl": null,
+			"cs": "Super Capacitor"
+		},
+		"Hi-cap": {
+			"es": null,
+			"pt": null,
+			"de": "Hi-cap",
+			"fr": null,
+			"ru": "Высокая емкость",
+			"pl": null,
+			"cs": "Hi-cap"
+		},
+		"Multi-weave": {
+			"es": null,
+			"pt": null,
+			"de": "Mehrfachgewebe",
+			"fr": null,
+			"ru": "Мультипрошивка",
+			"pl": null,
+			"cs": "Multi-weave"
+		},
+		"Fast Charge": {
+			"es": "Carga Rápida",
+			"pt": null,
+			"de": "Schnelllader",
+			"fr": null,
+			"ru": "Быстрый заряд",
+			"pl": null,
+			"cs": "Fast Charge"
+		},
+		"Lo-draw": {
+			"es": null,
+			"pt": null,
+			"de": "Lo-draw",
+			"fr": null,
+			"ru": "Пониженное потребление",
+			"pl": null,
+			"cs": "Lo-draw"
+		},
+		"Deep Charge": {
+			"es": "Carga Profunda",
+			"pt": null,
+			"de": "Tiefenladung",
+			"fr": null,
+			"ru": "Заряд повышенной мощности",
+			"pl": null,
+			"cs": "Deep Charge"
+		},
+		"Mass Manager": {
+			"es": "Gestor de Masa",
+			"pt": null,
+			"de": "Massemanager",
+			"fr": null,
+			"ru": "Распределитель гравитации",
+			"pl": null,
+			"cs": "Mass Manager"
+		},
+		"Drive Distributors": {
+			"es": "Distribuidores de Empuje",
+			"pt": null,
+			"de": "Antriebsverteiler",
+			"fr": null,
+			"ru": "Распределители тяги",
+			"pl": null,
+			"cs": "Drive Distributors"
+		},
+		"Drag Drives": {
+			"es": "Impulsores de Arrastre",
+			"pt": null,
+			"de": "Drag Antriebe",
+			"fr": null,
+			"ru": "Ускорители",
+			"pl": null,
+			"cs": "Drag Drives"
+		},
+		"Super Conduits": {
+			"es": "Superconductores",
+			"pt": null,
+			"de": "Superleiter",
+			"fr": null,
+			"ru": "Сверхпроводники",
+			"pl": null,
+			"cs": "Super Conduits"
+		},
+		"Cluster Capacitor": {
+			"es": "Condensador de Cluster",
+			"pt": null,
+			"de": "Cluster Kondensator",
+			"fr": null,
+			"ru": "Кассетный конденсатор",
+			"pl": null,
+			"cs": "Cluster Capacitor"
+		},
+		"Thargoid": {
+			"es": "Thargoide",
+			"pt": "Thargoid",
+			"de": "Thargoid",
+			"fr": null,
+			"ru": "Технологии таргоидов",
+			"pl": null,
+			"cs": "Thargoidské"
+		},
+		"Thargoid Ship": {
+			"es": "Nave Thargoide",
+			"pt": null,
+			"de": null,
+			"fr": null,
+			"ru": null,
+			"pl": null,
+			"cs": null
+		},
+		"Thargoid Site": {
+			"es": "Sitio Thargoide",
+			"pt": null,
+			"de": null,
+			"fr": null,
+			"ru": null,
+			"pl": null,
+			"cs": null
+		},
+		"Top Source Systems": {
+			"es": null,
+			"pt": null,
+			"de": "Top Quellsysteme",
+			"fr": null,
+			"ru": "Системы с обилием ресурсов",
+			"pl": null,
+			"cs": "Získáno nejvíce v systému"
+		},
+		"System:": {
+			"es": "Sistema:",
+			"pt": null,
+			"de": "System:",
+			"fr": null,
+			"ru": "Система:",
+			"pl": null,
+			"cs": "Systém:"
+		},
+		"You have:": {
+			"es": "Tienes:",
+			"pt": null,
+			"de": "Du hast:",
+			"fr": null,
+			"ru": "В наличии:",
+			"pl": null,
+			"cs": "Máš"
+		},
+		"(already needed)": {
+			"es": "(Es Necesario)",
+			"pt": null,
+			"de": "(bereits benötigt)",
+			"fr": null,
+			"ru": "(уже необходимо)",
+			"pl": null,
+			"cs": "(také potřebuješ)"
+		},
+		"Shows material trading suggestion (taking into account your cargo and the entire shopping list).": {
+			"es": "Muestra sugerencia de comercio de materiales (teniendo en cuenta tu carga y la lista de componentes completa).",
+			"pt": null,
+			"de": "Zeigt Materialhandelsvorschläge (unter Berücksichtigung Ihrer Ladung und der gesamten Einkaufsliste).",
+			"fr": null,
+			"ru": "Показывает предложения по торговле материалами (учитывая ваш груз и весь список покупок).",
+			"pl": null,
+			"cs": "Zobrazuje návrh obchodování s materiálem (s ohledem na vaše cargo a celý nákupní seznam)."
+		},
+		"Suggestions are sorted by how big the trade is compared to your cargo, minus an eventual amount already needed in the shopping list.": {
+			"es": "Las sugerencias están ordenadas por el tamaño de la transacción comparado con tu carga, menos una cantidad eventual necesaria para la lista de componentes.",
+			"pt": null,
+			"de": "Vorschläge werden nach der Größe des Handels im Vergleich zu Ihrer Ladung sortiert, abzüglich einer eventuell bereits in der Einkaufsliste benötigten Menge.",
+			"fr": null,
+			"ru": "Предложения сортируются по величине торговли по сравнению с вашим грузом, минус возможная сумма, уже необходимая в списке покупок.",
+			"pl": null,
+			"cs": "Návrhy jsou seřazeny podle toho, jak velký bude obchod v porovnání s materiály ve tvém cargu. Mínus případné položky, které jsou zapotřebí v nákupním seznamu."
+		},
+		"Orange entries indicates a trade suggestion that will not completely fulfill your requirement (but might help).": {
+			"es": "Las entradas naranjas indican una sugerencia de comercio que no completará tus requisitos (pero puede que ayude).",
+			"pt": null,
+			"de": "Orange Einträge weisen auf einen Handelsvorschlag hin, der Ihre Anforderung nicht vollständig erfüllt (aber helfen könnte).",
+			"fr": null,
+			"ru": "Оранжевые записи указывают предложения по торговле, которые не полностью отвечают требованиям (но могут помочь).",
+			"pl": null,
+			"cs": "Oranžové položky označují návrhy obchodu, které zcela nesplní tvůj požadavek, ale může ti pomoci."
+		},
+		"Materials Trader found at industrial economies, only trades in manufactured materials.": {
+			"es": "Los comerciantes de materiales encontrados en las economías industriales, solo hacen transacciones con materiales manufacturados.",
+			"pt": null,
+			"de": "Materialhändler in Industriesystemen, handeln nur mit verarbeiteten Materialien",
+			"fr": null,
+			"ru": "Торговец материалами в системах с промышленной экономикой, обменивает только промышленные материалы.",
+			"pl": null,
+			"cs": "Obchodník s materiály se může necházet v systémech s 'Industrial' ekonomikou, obchoduje pouze s vyrobenými materiály (Biotech conductors, Compound shielding atd.)."
+		},
+		"Materials Trader found at extraction and refinery economies, only trades in raw material found on planet surfaces and planetary rings.": {
+			"es": "Los comerciantes de materiales encontrados en las economías de estracción y refinería, solo hacen transacciones con materias primas encontradas en superficies de planetas y anillos planetarios.",
+			"pt": null,
+			"de": "Materialhändler, der in der Bergbau- und Raffineriewirtschaft tätig ist, handelt nur mit Rohstoffen, die auf Planetenoberflächen und Planetenringen vorkommen.",
+			"fr": null,
+			"ru": "Торговец материалами в системах с добычей ископаемых и переработкой, обменивает только сырьевые элементы.",
+			"pl": null,
+			"cs": "Obchodník s materiály se může necházet v systémech s 'Extraction' a 'Rafinery ekonomikou', obchoduje pouze se surovými materiály, které se získávají na povrchu planet a při težbě v prstencích."
+		},
+		"Materials Trader found at High Tech and Military economies, only trades in encoded materials.": {
+			"es": "Los comerciantes de materiales encontrados en las economías de alta tecnología y militares, solo hacen transacciones con materiales codificados.",
+			"pt": null,
+			"de": "Materialhändler in High-Tech- und Militär-Systemen, handeln nur mit verschlüsselten Materialien.",
+			"fr": null,
+			"ru": "Торговец материалами в системах с высокотехнологичной и военной экономикой, обменивает только зашифрованные данные.",
+			"pl": null,
+			"cs": "Obchodník s materiály se může necházet v systémech s 'High Tech' a 'Military ekonomikou', obchoduje pouze s daty."
+		},
+		"API ON": {
+			"es": "API encendida",
+			"pt": null,
+			"de": "API AN",
+			"fr": null,
+			"ru": "API ВКЛ",
+			"pl": null,
+			"cs": "API zapnuto"
+		},
+		"API OFF": {
+			"es": "API apagada",
+			"pt": null,
+			"de": "API AUS",
+			"fr": null,
+			"ru": "API ВЫКЛ",
+			"pl": null,
+			"cs": "API vypnuto"
+		},
+		"Long Range FSD Interdictor": {
+			"es": null,
+			"pt": null,
+			"de": null,
+			"fr": null,
+			"ru": "FSD-перехватчик большой дальности",
+			"pl": null,
+			"cs": "Long Range FSD Interdictor"
+		},
+		"Guardian Plasma Charger Munitions": {
+			"es": "Munición de Cargador de Plasma Guardián",
+			"pt": null,
+			"de": "Guardian-Plasmaladermunition",
+			"fr": null,
+			"ru": "Боеприпасы для плазменных пушек стражей",
+			"pl": null,
+			"cs": "Munice do Guardian Plasma Charger"
+		},
+		"Guardian Gauss Cannon Munitions": {
+			"es": "Munición de Cañón Gauss Guardián",
+			"pt": null,
+			"de": "Guardian-Gausskannonenmunition",
+			"fr": null,
+			"ru": "Боеприпасы для пушек Гаусса стражей",
+			"pl": null,
+			"cs": "Munice do Guardian Gauss Cannon"
+		},
+		"AX Small Calibre Munitions": {
+			"es": "Munición AX de calibre pequeño",
+			"pt": null,
+			"de": "Kleinkalibrige Munition (AX)",
+			"fr": null,
+			"ru": "Мелкокалиберные боеприпасы АИ",
+			"pl": null,
+			"cs": "Munice malé ráže do AX zbraní (AX MC)"
+		},
+		"+5% Damage Boost": {
+			"es": "Aumento de Daño +5%",
+			"pt": null,
+			"de": "Bonus Schaden: +5%",
+			"fr": null,
+			"ru": "+5% к урону",
+			"pl": null,
+			"cs": "+5% boost k poškození"
+		},
+		"+10% Damage Boost": {
+			"es": "Aumento de Daño +10%",
+			"pt": null,
+			"de": "Bonus Schaden: +10%",
+			"fr": null,
+			"ru": "+10% к урону",
+			"pl": null,
+			"cs": "+10% boost k poškození"
+		},
+		"AX Remote Flak Munitions": {
+			"es": null,
+			"pt": null,
+			"de": "Munition für Ferngezündete Flak (AX)",
+			"fr": null,
+			"ru": "Зенитные снаряды с дистанционным подрывом АИ",
+			"pl": null,
+			"cs": "Munice do AX Remote Flaku"
+		},
+		"Enzyme Missile Launcher Munitions": {
+			"es": null,
+			"pt": null,
+			"de": "Enzymraketenwerfermunition",
+			"fr": null,
+			"ru": "Боеприпасы для энзимных ракетных установок",
+			"pl": null,
+			"cs": "Munice do Enzyme Missile Launcher"
+		},
+		"Flechette Launcher Munitions": {
+			"es": null,
+			"pt": null,
+			"de": "Flechettewerfermunition",
+			"fr": null,
+			"ru": "Стреловидные боеприпасы",
+			"pl": null,
+			"cs": "Munice do Flechette Launcher"
+		},
+		"Guardian Shard Cannon Munitions": {
+			"es": null,
+			"pt": null,
+			"de": "Guardian-Fragmentkanonenmunition",
+			"fr": null,
+			"ru": "Боеприпасы для осколочных орудий стражей",
+			"pl": null,
+			"cs": "Munice do Guardian Shard Cannon"
+		},
+		"AX Explosive Munitions": {
+			"es": null,
+			"pt": null,
+			"de": "Explosivmunition (AX)",
+			"fr": null,
+			"ru": "Взрывчатые боеприпасы АИ",
+			"pl": null,
+			"cs": "Explozivní munice do AX zbraní (rakety)"
+		},
+		"+5% Damage": {
+			"es": "+5% Daño",
+			"pt": null,
+			"de": "Bonus Schaden: +5%",
+			"fr": null,
+			"ru": "+5% к урону",
+			"pl": null,
+			"cs": "+5% poškození"
+		},
+		"Guardian Gauss Cannon (Fixed, Medium)": {
+			"es": null,
+			"pt": null,
+			"de": "Guardian-Gausskanone (Fest) (Klasse: 2)",
+			"fr": null,
+			"ru": "Пушка Гаусса стражей (фиксированное, средний слот)",
+			"pl": null,
+			"cs": "Guardian Gauss Cannon (Fixed, Medium)"
+		},
+		"Guardian Gauss Cannon (Fixed, Small)": {
+			"es": null,
+			"pt": null,
+			"de": "Guardian-Gausskanone (Fest) (Klasse: 1)",
+			"fr": null,
+			"ru": "Пушка Гаусса стражей (фиксированное, малый слот)",
+			"pl": null,
+			"cs": "Guardian Gauss Cannon (Fixed, Small)"
+		},
+		"Guardian Hull Reinforcement": {
+			"es": null,
+			"pt": null,
+			"de": "Guardian-Rumpfhüllenverstärkung",
+			"fr": null,
+			"ru": "Набор для усиления корпуса стражей",
+			"pl": null,
+			"cs": "Guardian Hull Reinforcement"
+		},
+		"Guardian Module Reinforcement": {
+			"es": null,
+			"pt": null,
+			"de": "Guardian-Modulverstärkung",
+			"fr": null,
+			"ru": "Набор для усиления модуля стражей",
+			"pl": null,
+			"cs": "Guardian Module Reinforcement"
+		},
+		"Guardian Plasma Charger (Fixed, Large)": {
+			"es": null,
+			"pt": null,
+			"de": "Guardian-Plasmalader (Fest) (Klasse: 3)",
+			"fr": null,
+			"ru": "Плазменная пушка стражей (фиксированное, большой слот)",
+			"pl": null,
+			"cs": "Guardian Plasma Charger (Fixed, Large)"
+		},
+		"Guardian Plasma Charger (Fixed, Medium)": {
+			"es": null,
+			"pt": null,
+			"de": "Guardian-Plasmalader (Fest) (Klasse: 2)",
+			"fr": null,
+			"ru": "Плазменная пушка стражей (фиксированное, средний слот)",
+			"pl": null,
+			"cs": "Guardian Plasma Charger (Fixed, Medium)"
+		},
+		"Guardian Plasma Charger (Fixed, Small)": {
+			"es": null,
+			"pt": null,
+			"de": "Guardian-Plasmalader (Fest) (Klasse: 1)",
+			"fr": null,
+			"ru": "Плазменная пушка стражей (фиксированное, малый слот)",
+			"pl": null,
+			"cs": "Guardian Plasma Charger (Fixed, Small)"
+		},
+		"Guardian Plasma Charger (Turreted, Large)": {
+			"es": null,
+			"pt": null,
+			"de": "Guardian-Plasmalader (Turm) (Klasse: 3)",
+			"fr": null,
+			"ru": "Плазменная пушка стражей (турель, большой слот)",
+			"pl": null,
+			"cs": "Guardian Plasma Charger (Turreted, Large)"
+		},
+		"Guardian Plasma Charger (Turreted, Medium)": {
+			"es": null,
+			"pt": null,
+			"de": "Guardian-Plasmalader (Turm) (Klasse: 2)",
+			"fr": null,
+			"ru": "Плазменная пушка стражей (турель, средний слот)",
+			"pl": null,
+			"cs": "Guardian Plasma Charger (Turreted, Medium)"
+		},
+		"Guardian Plasma Charger (Turreted, Small)": {
+			"es": null,
+			"pt": null,
+			"de": "Guardian-Plasmalader (Turm) (Klasse: 1)",
+			"fr": null,
+			"ru": "Плазменная пушка стражей (турель, малый слот)",
+			"pl": null,
+			"cs": "Guardian Plasma Charger (Turreted, Small)"
+		},
+		"Guardian FSD Booster": {
+			"es": null,
+			"pt": null,
+			"de": "Guardian-Frameshiftantrieb-Booster",
+			"fr": null,
+			"ru": "Ускоритель FSD стражей",
+			"pl": null,
+			"cs": "Guardian FSD Booster"
+		},
+		"Guardian Power Distributor": {
+			"es": null,
+			"pt": null,
+			"de": "Guardian-Energieverteiler",
+			"fr": null,
+			"ru": "Распределитель питания стражей",
+			"pl": null,
+			"cs": "Guardian Power Distributor"
+		},
+		"Guardian Shard Cannon (Fixed, Large)": {
+			"es": null,
+			"pt": null,
+			"de": "Guardian-Fragmentkanone (Fest) (Klasse: 3)",
+			"fr": null,
+			"ru": "Осколочное орудие стражей (фиксированное, большой слот)",
+			"pl": null,
+			"cs": "Guardian Shard Cannon (Fixed, Large)"
+		},
+		"Guardian Shard Cannon (Fixed, Medium)": {
+			"es": null,
+			"pt": null,
+			"de": "Guardian-Fragmentkanone (Fest) (Klasse: 2)",
+			"fr": null,
+			"ru": "Осколочное орудие стражей (фиксированное, средний слот)",
+			"pl": null,
+			"cs": "Guardian Shard Cannon (Fixed, Medium)"
+		},
+		"Guardian Shard Cannon (Fixed, Small)": {
+			"es": null,
+			"pt": null,
+			"de": "Guardian-Fragmentkanone (Fest) (Klasse: 1)",
+			"fr": null,
+			"ru": "Осколочное орудие стражей (фиксированное, малый слот)",
+			"pl": null,
+			"cs": "Guardian Shard Cannon (Fixed, Small)"
+		},
+		"Guardian Shard Cannon (Turreted, Large)": {
+			"es": null,
+			"pt": null,
+			"de": "Guardian-Fragmentkanone (Turm) (Klasse: 3)",
+			"fr": null,
+			"ru": "Осколочное орудие стражей (турель, большой слот)",
+			"pl": null,
+			"cs": "Guardian Shard Cannon (Turreted, Large)"
+		},
+		"Guardian Shard Cannon (Turreted, Medium)": {
+			"es": null,
+			"pt": null,
+			"de": "Guardian-Fragmentkanone (Turm) (Klasse: 2)",
+			"fr": null,
+			"ru": "Осколочное орудие стражей (турель, средний слот)",
+			"pl": null,
+			"cs": "Guardian Shard Cannon (Turreted, Medium)"
+		},
+		"Guardian Shard Cannon (Turreted, Small)": {
+			"es": null,
+			"pt": null,
+			"de": "Guardian-Fragmentkanone (Turm) (Klasse: 1)",
+			"fr": null,
+			"ru": "Осколочное орудие стражей (турель, малый слот)",
+			"pl": null,
+			"cs": "Guardian Shard Cannon (Turreted, Small)"
+		},
+		"Guardian Shield Reinforcement": {
+			"es": null,
+			"pt": null,
+			"de": "Guardian-Schildverstärkung",
+			"fr": null,
+			"ru": "Набор для усиления щита стражей",
+			"pl": null,
+			"cs": "Guardian Shield Reinforcement"
+		},
+		"Javelin (Fighter)": {
+			"es": null,
+			"pt": null,
+			"de": "Javelin (Fighter)",
+			"fr": null,
+			"ru": "Javelin (Истребитель)",
+			"pl": null,
+			"cs": "Javelin (Fighter)"
+		},
+		"Lance (Fighter)": {
+			"es": null,
+			"pt": null,
+			"de": "Lance (Fighter)",
+			"fr": null,
+			"ru": "Lance (Истребитель)",
+			"pl": null,
+			"cs": "Lance (Fighter)"
+		},
+		"Trident (Fighter)": {
+			"es": null,
+			"pt": null,
+			"de": "Trident (Fighter)",
+			"fr": null,
+			"ru": "Trident (Истребитель)",
+			"pl": null,
+			"cs": "Trident (Fighter)"
+		},
+		"Shock Cannon (Fixed, Large)": {
+			"es": null,
+			"pt": null,
+			"de": null,
+			"fr": null,
+			"ru": "Осколочное орудие стражей (фиксированное, большой слот)",
+			"pl": null,
+			"cs": "Shock Cannon (Fixed, Large)"
+		},
+		"Shock Cannon (Fixed, Medium)": {
+			"es": null,
+			"pt": null,
+			"de": null,
+			"fr": null,
+			"ru": "Шоковое орудие (фиксированное, средний слот)",
+			"pl": null,
+			"cs": "Shock Cannon (Fixed, Medium)"
+		},
+		"Shock Cannon (Fixed, Small)": {
+			"es": null,
+			"pt": null,
+			"de": null,
+			"fr": null,
+			"ru": "Шоковое орудие (фиксированное, малый слот)",
+			"pl": null,
+			"cs": "Shock Cannon (Fixed, Small)"
+		},
+		"Shock Cannon (Gimballed, Large)": {
+			"es": null,
+			"pt": null,
+			"de": null,
+			"fr": null,
+			"ru": "Шоковое орудие (на карданной подвеске, большой слот)",
+			"pl": null,
+			"cs": "Shock Cannon (Gimballed, Large)"
+		},
+		"Shock Cannon (Gimballed, Medium)": {
+			"es": null,
+			"pt": null,
+			"de": null,
+			"fr": null,
+			"ru": "Шоковое орудие (на карданной подвеске, средний слот)",
+			"pl": null,
+			"cs": "Shock Cannon (Gimballed, Medium)"
+		},
+		"Shock Cannon (Gimballed, Small)": {
+			"es": null,
+			"pt": null,
+			"de": null,
+			"fr": null,
+			"ru": "Шоковое орудие (на карданной подвеске, малый слот)",
+			"pl": null,
+			"cs": "Shock Cannon (Gimballed, Small)"
+		},
+		"Shock Cannon (Turreted, Large)": {
+			"es": null,
+			"pt": null,
+			"de": null,
+			"fr": null,
+			"ru": "Шоковое орудие (турель, большой слот)",
+			"pl": null,
+			"cs": "Shock Cannon (Turreted, Large)"
+		},
+		"Shock Cannon (Turreted, Medium)": {
+			"es": null,
+			"pt": null,
+			"de": null,
+			"fr": null,
+			"ru": "Шоковое орудие (турель, средний слот)",
+			"pl": null,
+			"cs": "Shock Cannon (Turreted, Medium)"
+		},
+		"Shock Cannon (Turreted, Small)": {
+			"es": null,
+			"pt": null,
+			"de": null,
+			"fr": null,
+			"ru": "Шоковое орудие (турель, малый слот)",
+			"pl": null,
+			"cs": "Shock Cannon (Turreted, Small)"
+		},
+		"Ship Value:": {
+			"es": null,
+			"pt": null,
+			"de": "Wert dieses Shiffs",
+			"fr": null,
+			"ru": "Стоимость корабля:",
+			"pl": null,
+			"cs": "Cena lodi:"
+		},
+		"Modules Value:": {
+			"es": null,
+			"pt": null,
+			"de": "Wert der Module",
+			"fr": null,
+			"ru": "Стоимость модулей:",
+			"pl": null,
+			"cs": "Cena modulů:"
+		},
+		"Rebuy:": {
+			"es": null,
+			"pt": null,
+			"de": "Ersatzwert",
+			"fr": null,
+			"ru": "Страховка:",
+			"pl": null,
+			"cs": "Rebuy:"
+		},
+		"Loadout": {
+			"es": null,
+			"pt": null,
+			"de": "Ausrüstung",
+			"fr": null,
+			"ru": "Оснащение",
+			"pl": null,
+			"cs": "Výzbroj"
+		},
+		"Cargo History (require API)": {
+			"es": null,
+			"pt": null,
+			"de": "Fracht Historie (Benötigt API)",
+			"fr": null,
+			"ru": "История грузов (необходимо API)",
+			"pl": null,
+			"cs": "Historie nákladu (vyžaduje API)"
+		},
+		"Hardpoints": {
+			"es": null,
+			"pt": null,
+			"de": "Aufhängungen",
+			"fr": null,
+			"ru": "Орудийные гнезда",
+			"pl": null,
+			"cs": "Hardpoints"
+		},
+		"Utilities": {
+			"es": null,
+			"pt": null,
+			"de": "Werkzeuge",
+			"fr": null,
+			"ru": "Крепления утилит",
+			"pl": null,
+			"cs": "Utilities"
+		},
+		"Core Internal": {
+			"es": null,
+			"pt": null,
+			"de": "Intern (Basis)",
+			"fr": null,
+			"ru": "Зарезервированные слоты",
+			"pl": null,
+			"cs": "Core Internal"
+		},
+		"Optional Internal": {
+			"es": null,
+			"pt": null,
+			"de": "Intern (Optional)",
+			"fr": null,
+			"ru": "Опциональные модули",
+			"pl": null,
+			"cs": "Optional Internal"
+		},
+		"Others/Livery": {
+			"es": null,
+			"pt": null,
+			"de": "Diverses/Lackierung",
+			"fr": null,
+			"ru": "Прочее/Декали",
+			"pl": null,
+			"cs": "Ostatní/Livery"
+		},
+		"Occupied Escape Pod": {
+			"es": null,
+			"pt": null,
+			"de": "Besetzte Rettungskapsel",
+			"fr": null,
+			"ru": "Спасательная капсула с пассажиром",
+			"pl": null,
+			"cs": "Occupied Escape Pod"
+		},
+		"Progenitor Cells": {
+			"es": null,
+			"pt": null,
+			"de": "Vorläuferzellen",
+			"fr": null,
+			"ru": "Прогениторные клетки",
+			"pl": null,
+			"cs": "Progenitor Cells"
+		},
+		"Sync?": {
+			"es": null,
+			"pt": null,
+			"de": "Synchronisieren?",
+			"fr": null,
+			"ru": "Синхронизировать?",
+			"pl": null,
+			"cs": "Synchronizovat?"
+		},
+		"Guardian Wreckage Components": {
+			"es": "Restos de Accidentes de Guardián",
+			"pt": null,
+			"de": "Guardian-Wrackteilkomponenten",
+			"fr": null,
+			"ru": "Обломки часовых стражей",
+			"pl": null,
+			"cs": "Guardian Wreckage Components"
+		},
+		"Reload all data": {
+			"es": null,
+			"pt": null,
+			"de": null,
+			"fr": null,
+			"ru": null,
+			"pl": null,
+			"cs": "Znovu načíst všechna data"
+		}
+	}
 }


### PR DESCRIPTION
- Split Thargoid items into "Thargoid Ship" and "Thargoid Site"
- Split Guardian items into "Guardian Ruins" and "Guardian Ruins (Active)"
- Amended Group.cs to remove Thargoid & Guardian groups and replace with ThargoidShip, ThargoidSite, GuardianRuins & GuardianRuinsActive
- Added IsTradeable() method to EntryData class
- Added localisation for new group names (only Spanish translated)
- Added Spanish translations for all items in new groups to test localisation