### PR TITLE
Add missing unlocks

### DIFF
--- a/EDEngineer/Resources/Data/blueprints.json
+++ b/EDEngineer/Resources/Data/blueprints.json
@@ -33468,7 +33468,7 @@
     ],
     "Ingredients": [
       {
-        "Name": "Occupied Escape Pods",
+        "Name": "Occupied Escape Pod",
         "Size": 25
       }
     ]
@@ -33481,7 +33481,7 @@
     ],
     "Ingredients": [
       {
-        "Name": "Sensor Fragments",
+        "Name": "Sensor Fragment",
         "Size": 25
       }
     ]

--- a/EDEngineer/Resources/Data/blueprints.json
+++ b/EDEngineer/Resources/Data/blueprints.json
@@ -33435,6 +33435,58 @@
     ]
   },
   {
+    "Type": "Unlock",
+    "Name": "Marsha Hicks",
+    "Engineers": [
+      "Marsha Hicks"
+    ],
+    "Ingredients": [
+      {
+        "Name": "Osmium",
+        "Size": 10
+      }
+    ]
+  },
+  {
+    "Type": "Unlock",
+    "Name": "Petra Olmanova",
+    "Engineers": [
+      "Petra Olmanova"
+    ],
+    "Ingredients": [
+      {
+        "Name": "Progenitor Cells",
+        "Size": 200
+      }
+    ]
+  },
+  {
+    "Type": "Unlock",
+    "Name": "Etienne Dorn",
+    "Engineers": [
+      "Etienne Dorn"
+    ],
+    "Ingredients": [
+      {
+        "Name": "Occupied Escape Pods",
+        "Size": 25
+      }
+    ]
+  },
+  {
+    "Type": "Unlock",
+    "Name": "Chloe Sedesi",
+    "Engineers": [
+      "Chloe Sedesi"
+    ],
+    "Ingredients": [
+      {
+        "Name": "Sensor Fragments",
+        "Size": 25
+      }
+    ]
+  },
+  {
     "Type": "Human",
     "Name": "Corrosion Resistant Cargo Rack (2D and 4D)",
     "Engineers": [


### PR DESCRIPTION
Add the missing unlock data for the Colonia and Witch Head engineers that require commodities to unlock.