### PR TITLE
Split 3 blueprints (Kinematic, Takada, Manticore). Added Odyssey consumables as materials

### DIFF
--- a/EDEngineer/Resources/Data/blueprints.json
+++ b/EDEngineer/Resources/Data/blueprints.json
@@ -40802,12 +40802,55 @@
   },
   {
     "Type": "Weapon",
-    "Name": "Greater range",
+    "Name": "Greater range (Manticore plasma)",
     "Engineers": [
       "Domino Green",
       "Wellington Beck"
     ],
     "Ingredients": [
+      {
+        "Name": "Ionised Gas",
+        "Size": 1
+      },
+      {
+        "Name": "Chemical Formulae",
+        "Size": 10
+      },
+      {
+        "Name": "Mineral Survey",
+        "Size": 15
+      },
+      {
+        "Name": "Metal Coil",
+        "Size": 10
+      },
+      {
+        "Name": "Motor",
+        "Size": 5
+      },
+      {
+        "Name": "Electromagnet",
+        "Size": 10
+      },
+      {
+        "Name": "Electrical Fuse",
+        "Size": 5
+      }
+    ],
+    "Effects": []
+    },
+    {
+    "Type": "Weapon",
+    "Name": "Greater range (Kinematic kinetic)",
+    "Engineers": [
+      "Domino Green",
+      "Wellington Beck"
+    ],
+    "Ingredients": [
+      {
+        "Name": "Compression-Liquefied Gas",
+        "Size": 1
+      },
       {
         "Name": "Ballistic Data",
         "Size": 10
@@ -40827,6 +40870,45 @@
       {
         "Name": "Weapon Component",
         "Size": 5
+      }
+    ],
+    "Effects": []
+  },
+  {
+    "Type": "Weapon",
+    "Name": "Greater range (Takada laser)",
+    "Engineers": [
+      "Domino Green",
+      "Wellington Beck"
+    ],
+    "Ingredients": [
+      {
+        "Name": "Ionised Gas",
+        "Size": 1
+      },
+      {
+        "Name": "Stellar Activity Logs",
+        "Size": 10
+      },
+      {
+        "Name": "Risk Assessments",
+        "Size": 10
+      },
+      {
+        "Name": "Ion Battery",
+        "Size": 25
+      },
+      {
+        "Name": "Micro Transformer",
+        "Size": 15
+      },
+      {
+        "Name": "Optical Lens",
+        "Size": 5
+      },
+      {
+        "Name": "Circuit Board",
+        "Size": 3
       }
     ],
     "Effects": []
@@ -41150,7 +41232,8 @@
     "Type": "Weapon",
     "Name": "Faster handling",
     "Engineers": [
-      "Hero Ferrari"
+      "Hero Ferrari",
+      "Yarden Bond"
     ],
     "Ingredients": [
       {
@@ -41174,14 +41257,105 @@
   },
   {
     "Type": "Weapon",
-    "Name": "Improved Hip Fire Accuracy",
+    "Name": "Improved Hip Fire Accuracy (Manticore plasma)",
     "Engineers": [
-      "Terra Velasquez"
+      "Terra Velasquez",
+      "Yarden Bond"
     ],
     "Ingredients": [
       {
-        "Name": "Optical Lens",
+        "Name": "Chemical Patents",
         "Size": 5
+      },
+      {
+        "Name": "Combatant Performance",
+        "Size": 10
+      },
+      {
+        "Name": "Weapon Component",
+        "Size": 5
+      },
+      {
+        "Name": "Microelectrode",
+        "Size": 20
+      },
+      {
+        "Name": "Electrical Wiring",
+        "Size": 30
+      },
+      {
+        "Name": "Chemical Catalyst",
+        "Size": 10
+      },
+      {
+        "Name": "Electromagnet",
+        "Size": 10
+      },
+      {
+        "Name": "Metal Coil",
+        "Size": 10
+      }
+    ],
+    "Effects": []
+  },
+  {
+    "Type": "Weapon",
+    "Name": "Improved Hip Fire Accuracy (Kinematic kinetic)",
+    "Engineers": [
+      "Terra Velasquez",
+      "Yarden Bond"
+    ],
+    "Ingredients": [
+      {
+        "Name": "Extraction Yield Data",
+        "Size": 10
+      },
+      {
+        "Name": "Biometric Data",
+        "Size": 5
+      },
+      {
+        "Name": "Combatant Performance",
+        "Size": 10
+      },
+      {
+        "Name": "Weapon Component",
+        "Size": 5
+      },
+      {
+        "Name": "Electromagnet",
+        "Size": 20
+      },
+      {
+        "Name": "Metal Coil",
+        "Size": 20
+      },
+      {
+        "Name": "Viscoelastic Polymer",
+        "Size": 10
+      },
+      {
+        "Name": "RDX",
+        "Size": 10
+      }
+    ],
+    "Effects": []
+  },
+  {
+    "Type": "Weapon",
+    "Name": "Improved Hip Fire Accuracy (Takada laser)",
+    "Engineers": [
+      "Terra Velasquez",
+      "Yarden Bond"
+    ],
+    "Ingredients": [
+      {
+        "Name": "Radioactivity Data",
+        "Size": 5
+      },
+      {
+        "Name": "Combatant Performance",
+        "Size": 10
       },
       {
         "Name": "Aerogel",
@@ -41196,12 +41370,12 @@
         "Size": 10
       },
       {
-        "Name": "Electrical Wiring",
-        "Size": 15
+        "Name": "Optical Lens",
+        "Size": 5
       },
       {
-        "Name": "Radioactivity Data",
-        "Size": 5
+        "Name": "Electrical Wiring",
+        "Size": 15
       }
     ],
     "Effects": []
@@ -41210,7 +41384,8 @@
     "Type": "Suit",
     "Name": "Improved jump assist",
     "Engineers": [
-      "Hero Ferrari"
+      "Hero Ferrari",
+      "Yarden Bond"
     ],
     "Ingredients": [
       {
@@ -41377,11 +41552,45 @@
   },
   {
     "Type": "Weapon",
-    "Name": "Headshot damage",
+    "Name": "Headshot damage (Manticore plasma)",
     "Engineers": [
       "Uma Laszlo"
     ],
     "Ingredients": [
+      {
+        "Name": "Chemical Experiment Data",
+        "Size": 10
+      },
+      {
+        "Name": "Blood Test Results",
+        "Size": 5
+      },
+      {
+        "Name": "Ion Battery",
+        "Size": 10
+      },
+      {
+        "Name": "Electromagnet",
+        "Size": 10
+      },
+      {
+        "Name": "Micro Supercapacitor",
+        "Size": 15
+      }
+    ],
+    "Effects": []
+  },
+  {
+    "Type": "Weapon",
+    "Name": "Headshot damage (Kinematic kinetic)",
+    "Engineers": [
+      "Uma Laszlo"
+    ],
+    "Ingredients": [
+      {
+        "Name": "Frag Grenade",
+        "Size": 25
+      },
       {
         "Name": "Weapon Test Data",
         "Size": 10
@@ -41401,6 +41610,48 @@
       {
         "Name": "Weapon Component",
         "Size": 5
+      }
+    ],
+    "Effects": []
+  },
+  {
+    "Type": "Weapon",
+    "Name": "Headshot damage (Takada laser)",
+    "Engineers": [
+      "Uma Laszlo"
+    ],
+    "Ingredients": [
+      {
+        "Name": "Shield Disruptor",
+        "Size": 20
+      },
+      {
+        "Name": "Ionised Gas",
+        "Size": 1
+      },
+      {
+        "Name": "Spectral Analysis Data",
+        "Size": 10
+      },
+      {
+        "Name": "Biometric Data",
+        "Size": 5
+      },
+      {
+        "Name": "Weapon Component",
+        "Size": 1
+      },
+      {
+        "Name": "ion Battery",
+        "Size": 10
+      },
+      {
+        "Name": "Optical Lens",
+        "Size": 5
+      },
+      {
+        "Name": "Scrambler",
+        "Size": 10
       }
     ],
     "Effects": []
@@ -41589,7 +41840,8 @@
     "Type": "Suit",
     "Name": "Combat Movement Speed",
     "Engineers": [
-      "Terra Velasquez"
+      "Terra Velasquez",
+      "Yarden Bond"
     ],
     "Ingredients": [
       {

--- a/EDEngineer/Resources/Data/entryData.json
+++ b/EDEngineer/Resources/Data/entryData.json
@@ -5332,5 +5332,71 @@
       "CMD"
     ],
     "ContainerType": []
+  },
+  {
+    "Name": "Frag Grenade",
+    "FormattedName": "amm_grenade_frag",
+    "Kind": "OdysseyIngredient",
+    "OriginDetails": [],
+    "Group": "Consumables",
+    "ValueCr": 2000,
+    "SettlementType": [],
+    "BuildingType": [],
+    "ContainerType": []
+  },
+  {
+    "Name": "Medkit",
+    "FormattedName": "healthpack",
+    "Kind": "OdysseyIngredient",
+    "OriginDetails": [],
+    "Group": "Consumables",
+    "ValueCr": 1000,
+    "SettlementType": [],
+    "BuildingType": [],
+    "ContainerType": []
+  },
+  {
+    "Name": "Energy Cell",
+    "FormattedName": "energycell",
+    "Kind": "OdysseyIngredient",
+    "OriginDetails": [],
+    "Group": "Consumables",
+    "ValueCr": 1000,
+    "SettlementType": [],
+    "BuildingType": [],
+    "ContainerType": []
+  },
+  {
+    "Name": "Shield Disruptor",
+    "FormattedName": "amm_grenade_emp",
+    "Kind": "OdysseyIngredient",
+    "OriginDetails": [],
+    "Group": "Consumables",
+    "ValueCr": 2000,
+    "SettlementType": [],
+    "BuildingType": [],
+    "ContainerType": []
+  },
+  {
+    "Name": "Shield Projector",
+    "FormattedName": "amm_grenade_shield",
+    "Kind": "OdysseyIngredient",
+    "OriginDetails": [],
+    "Group": "Consumables",
+    "ValueCr": 2000,
+    "SettlementType": [],
+    "BuildingType": [],
+    "ContainerType": []
+  },
+  {
+    "Name": "E-Breach",
+    "FormattedName": "bypass",
+    "Kind": "OdysseyIngredient",
+    "OriginDetails": [],
+    "Group": "Consumables",
+    "ValueCr": -1,
+    "SettlementType": [],
+    "BuildingType": [],
+    "ContainerType": []
   }
 ]


### PR DESCRIPTION
Bluprints:
Headshot damage
Improved Hip Fire Accuracy
Grater Range
now split into diffrent blueprints for Kinematic, Takada, Manticore.
Added all Odyssey consumables to entryData.json with new group "Consumables" (as named in journal)
Some of these are used in blueprint for Headshot Damage
Added Yarden Bond to Blueprints according to INARA data.
Bluprint Data collected from INARA

This should address the refrence data side of issue #621 and #630 