### PR TITLE
Corrected material costs for Modified Plasma, Modified Shard

### DIFF
--- a/EDEngineer/Resources/Data/blueprints.json
+++ b/EDEngineer/Resources/Data/blueprints.json
@@ -34862,19 +34862,19 @@
       },
       {
         "Name": "Guardian Power Cell",
-        "Size": 18
+        "Size": 5
       },
       {
         "Name": "Guardian Technology Component",
-        "Size": 20
+        "Size": 5
       },
       {
         "Name": "Niobium",
-        "Size": 15
+        "Size": 4
       },
       {
         "Name": "Thermal Cooling Units",
-        "Size": 6
+        "Size": 2
       }
     ]
   },
@@ -34891,19 +34891,19 @@
       },
       {
         "Name": "Guardian Power Conduit",
-        "Size": 12
+        "Size": 3
       },
       {
         "Name": "Guardian Wreckage Components",
-        "Size": 12
+        "Size": 3
       },
       {
         "Name": "Guardian Sentinel Weapon Parts",
-        "Size": 15
+        "Size": 4
       },
       {
         "Name": "Niobium",
-        "Size": 9
+        "Size": 2
       }
     ]
   },
@@ -34916,7 +34916,7 @@
     "Ingredients": [
       {
         "Name": "Guardian Technology Component",
-        "Size": 18
+        "Size": 5
       },
       {
         "Name": "Guardian Weapon Blueprint Segment",
@@ -34924,15 +34924,15 @@
       },
       {
         "Name": "Guardian Wreckage Components",
-        "Size": 20
+        "Size": 5
       },
       {
         "Name": "Germanium",
-        "Size": 14
+        "Size": 4
       },
       {
         "Name": "Power Converter",
-        "Size": 12
+        "Size": 2
       }
     ]
   },
@@ -34949,19 +34949,19 @@
       },
       {
         "Name": "Guardian Power Conduit",
-        "Size": 12
+        "Size": 3
       },
       {
         "Name": "Guardian Wreckage Components",
-        "Size": 12
+        "Size": 3
       },
       {
         "Name": "Guardian Sentinel Weapon Parts",
-        "Size": 15
+        "Size": 4
       },
       {
         "Name": "Germanium",
-        "Size": 6
+        "Size": 2
       }
     ]
   },


### PR DESCRIPTION
I was at Bright Sentinel in Maia earlier to get me some Salvation merch and noticed a mismatch between the actual material costs and those used by EDEngineer. 

![modified gauss medium cost](https://user-images.githubusercontent.com/78969471/172242691-ed2ca01f-6361-440b-b51a-c41e51f7213b.jpg)
![modified gauss small cost](https://user-images.githubusercontent.com/78969471/172242696-668ab354-ac48-452f-9529-8aa3e5231def.jpg)
![modified shard medium cost](https://user-images.githubusercontent.com/78969471/172242699-b7b31751-30c8-4e48-b292-5a7ecb518659.jpg)
![modified shard small cost](https://user-images.githubusercontent.com/78969471/172242701-47f0b2bf-ac3e-4f60-8fd6-1b4b4e887588.jpg)
