### PR TITLE
Optimize EDEngineer

### DIFF
--- a/EDEngineer/Views/CommanderViewModel.cs
+++ b/EDEngineer/Views/CommanderViewModel.cs
@@ -242,7 +242,6 @@ namespace EDEngineer.Views
                     if (Settings.Default.Favorites.Contains($"{blueprint}"))
                     {
                         Settings.Default.Favorites.Remove($"{blueprint}");
-                        Settings.Default.Save();
                     }
                 }
                 else if (Settings.Default.Favorites.Contains($"{blueprint}"))
@@ -251,7 +250,6 @@ namespace EDEngineer.Views
                     favoritedBlueprints.Add(blueprint);
                     Settings.Default.Favorites.Remove($"{blueprint}");
                     Settings.Default.Favorites.Add(text);
-                    Settings.Default.Save();
                 }
 
                 if (Settings.Default.Ignored.Contains(text))
@@ -261,7 +259,6 @@ namespace EDEngineer.Views
                     if (Settings.Default.Ignored.Contains($"{blueprint}"))
                     {
                         Settings.Default.Ignored.Remove($"{blueprint}");
-                        Settings.Default.Save();
                     }
                 }
                 else if (Settings.Default.Ignored.Contains($"{blueprint}"))
@@ -269,7 +266,6 @@ namespace EDEngineer.Views
                     blueprint.Ignored = true;
                     Settings.Default.Ignored.Remove($"{blueprint}");
                     Settings.Default.Ignored.Add(text);
-                    Settings.Default.Save();
                 }
 
                 blueprint.ShoppingListCount = Settings.Default.ShoppingList.Cast<string>().Count(l => l == text);
@@ -321,6 +317,7 @@ namespace EDEngineer.Views
                 };
             }
 
+            Settings.Default.Save();
             Filters = new BlueprintFilters(languages, State.Blueprints);
 
             ShoppingList = new ShoppingListViewModel(State.Cargo, State.Blueprints, languages);

--- a/EDEngineer/Views/ShoppingListViewModel.cs
+++ b/EDEngineer/Views/ShoppingListViewModel.cs
@@ -18,12 +18,25 @@ namespace EDEngineer.Views
         private readonly StateCargo stateCargo;
         private readonly ILanguage languages;
         private readonly List<IGrouping<Tuple<string, string>, Blueprint>> blueprints;
+        public List<Blueprint> list = null;
 
         public ShoppingListViewModel(StateCargo stateCargo, List<Blueprint> blueprints, ILanguage languages)
         {
             this.blueprints = blueprints.GroupBy(b => Tuple.Create(b.Type, b.BlueprintName)).ToList();
             this.stateCargo = stateCargo;
             this.languages = languages;
+            list = this.ToList();
+
+            foreach (var blueprint in blueprints)
+            {
+                blueprint.PropertyChanged += (o, e) =>
+                                             {
+                                                 if (e.PropertyName == "ShoppingListCount")
+                                                 {
+                                                     list = this.ToList();
+                                                 }
+                                             };
+            }
 
             foreach (var ingredientsValue in stateCargo.Ingredients)
             {
@@ -44,7 +57,7 @@ namespace EDEngineer.Views
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
 
-        public List<Blueprint> List => this.ToList();
+        public List<Blueprint> List => list;
         public ILanguage Languages => this.languages;
 
         public List<Tuple<Blueprint, int>> Composition
@@ -205,13 +218,13 @@ namespace EDEngineer.Views
         }
 
         public Dictionary<EntryData, int> Deduction =>
-            this.ToList()
+                list
                 .FirstOrDefault()
                 ?.Ingredients
                 .ToDictionary(i => i.Entry.Data, i => i.Size);
 
         public Dictionary<Entry, int> MissingIngredients =>
-            this.ToList()
+                list
                 .FirstOrDefault()
                 ?.Ingredients
                 .Where(i => i.Size - i.Entry.Count > 0)

--- a/EDEngineer/Views/ShoppingListViewModel.cs
+++ b/EDEngineer/Views/ShoppingListViewModel.cs
@@ -55,7 +55,7 @@ namespace EDEngineer.Views
             MissingIngredients.Map(i => MaterialTrader.FindPossibleTrades(stateCargo, i, Deduction))
                               ?.GroupBy(i => i.Needed)
                               .OrderBy(i => languages.Translate(i.Key.Data.Name))
-                              .ToDictionary(i => Tuple.Create(i.Key.Data, i.First().WillBeEnough, i.First().Missing), i => i.OrderBy(j => j.Consumption).Take(4).ToList()); 
+                              .ToDictionary(i => Tuple.Create(i.Key.Data, i.First().WillBeEnough, i.First().Missing), i => i.OrderBy(j => j.Consumption).Take(4).ToList());
 
         public List<ShoppingListBlock> CompositionForGui
         {
@@ -219,27 +219,35 @@ namespace EDEngineer.Views
 
         public IEnumerator<Blueprint> GetEnumerator()
         {
-            var ingredients = blueprints
-                .SelectMany(b => b)
-                .SelectMany(b => Enumerable.Repeat(b, b.ShoppingListCount))
-                .SelectMany(b => b.Ingredients)
-                .ToList();
+            var ingredients = new Dictionary<Entry, int>();
+            foreach (var b in blueprints.SelectMany(b => b).Where(b => b.ShoppingListCount > 0))
+            {
+                foreach (var ingredient in b.Ingredients)
+                {
+                    if (!ingredients.ContainsKey(ingredient.Entry))
+                    {
+                        ingredients[ingredient.Entry] = 0;
+                    }
+                    ingredients[ingredient.Entry] += ingredient.Size * b.ShoppingListCount;
+                }
+            }
 
             if (!ingredients.Any())
             {
                 yield break;
             }
 
-            var composition = ingredients.GroupBy(i => i.Entry.Data.Name)
-                                         .Select(
-                                             i =>
-                                                 new BlueprintIngredient(i.First().Entry,
-                                                     i.Sum(c => c.Size)))
-                                         .OrderBy(i => i.Entry.Count - i.Size > 0 ? 1 : 0)
-                                         .ThenByDescending(i => i.Entry.Data.Subkind)
-                                         .ThenBy(i => i.Entry.Data.Kind)
-                                         .ThenBy(i => languages.Translate(i.Entry.Data.Name))
-                                         .ToList();
+            var composition = new List<BlueprintIngredient>();
+            foreach (var i in ingredients)
+            {
+                composition.Add(new BlueprintIngredient(i.Key, i.Value));
+            }
+
+            composition = composition.OrderBy(i => i.Entry.Count - i.Size > 0 ? 1 : 0)
+                                     .ThenByDescending(i => i.Entry.Data.Subkind)
+                                     .ThenBy(i => i.Entry.Data.Kind)
+                                     .ThenBy(i => languages.Translate(i.Entry.Data.Name))
+                                     .ToList();
 
             var metaBlueprint = new Blueprint(languages,
                 "",


### PR DESCRIPTION
ED Engineer operates very slow, especially on large shopping lists.

There are some bottlenecks and excessive operations when updating UI or importing/clearing shopping lists.

For example:
Multiple calling this.ToList(), which calculates a new object while we can store it somewhere if it's unchanged.
Updating UI or saving settings when importing or clearing shopping list (both are time expensive)

[source branch was renamed]